### PR TITLE
Stringify once for batch requests. Refs #18.

### DIFF
--- a/src/client/http.js
+++ b/src/client/http.js
@@ -131,15 +131,17 @@ class HTTPClient extends Client {
 
     return new Promise((resolve, reject) => {
       const batchIds = [];
+      const batchRequests = [];
       for (const request of requests) {
         const json = JSON.parse(request);
+        batchRequests.push(json);
         if (json.id) {
           batchIds.push(json.id);
         }
       }
       this.pendingBatches[String(batchIds)] = { resolve, reject };
 
-      const request = JSON.stringify(requests);
+      const request = JSON.stringify(batchRequests);
       this.options.headers["Content-Length"] = Buffer.byteLength(
         request,
         this.options.encoding

--- a/src/client/tcp.js
+++ b/src/client/tcp.js
@@ -119,14 +119,16 @@ class TCPClient extends Client {
 
     return new Promise((resolve, reject) => {
       const batchIds = [];
+      const batchRequests = [];
       for (const request of requests) {
         const json = JSON.parse(request);
+        batchRequests.push(json);
         if (json.id) {
           batchIds.push(json.id);
         }
       }
       this.pendingBatches[String(batchIds)] = { resolve, reject };
-      const request = JSON.stringify(requests);
+      const request = JSON.stringify(batchRequests);
       try {
         this.client.write(request + this.options.delimiter);
       } catch (e) {


### PR DESCRIPTION
Confirmed in ngrep that batch request objects dont get stringified.

```
T 127.0.0.1:35712 -> 127.0.0.1:8100 [AP] #64
  [{"method":"add","jsonrpc":"2.0","params":[1,2],"id":3},{"method":"add","jsonrpc":"2.0","params":[3,4],"id":4}]. 
```