### PR TITLE
Bugfix/#20/reject stringified batch objects

### DIFF
--- a/src/client/http.js
+++ b/src/client/http.js
@@ -169,25 +169,33 @@ class HTTPClient extends Client {
           }
         });
         if (_.isEmpty(batchResponseIds)) {
-          resolve([]);
+          const response = {
+            body: [],
+            ...this.writer
+          };
+          resolve(response);
         }
         for (const ids of Object.keys(this.pendingBatches)) {
           if (
             _.isEmpty(_.difference(JSON.parse(`[${ids}]`), batchResponseIds))
           ) {
+            const response = {
+              body: batch,
+              ...this.writer
+            };
             batch.forEach((message) => {
               if (message.error) {
                 // reject the whole message if there are any errors
-                this.pendingBatches[ids].reject(batch);
+                this.pendingBatches[ids].reject(response);
               }
             });
-            this.pendingBatches[ids].resolve(batch);
+            this.pendingBatches[ids].resolve(response);
           }
         }
       });
-      // this.on("batchError", (error) => {
-      //   reject(error);
-      // });
+      this.on("batchError", (error) => {
+        reject(error);
+      });
     });
   }
 }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -163,7 +163,7 @@ class Client extends EventEmitter {
           if (!message.method) {
             this.serving_message_id = message.id;
             this.responseQueue[this.serving_message_id] = message;
-            this.handleResponse(this.serving_message_id);
+            return this.handleResponse(this.serving_message_id);
           }
         }
       } catch (e) {

--- a/src/client/tcp.js
+++ b/src/client/tcp.js
@@ -48,11 +48,11 @@ class TCPClient extends Client {
 
   request() {
     return {
-      message: (method, params) => {
+      message: (method, params, id = true) => {
         const request = formatRequest({
           method,
           params,
-          id: this.message_id,
+          id: id ? this.message_id : undefined,
           options: this.options
         });
         this.message_id += 1;

--- a/src/client/tcp.js
+++ b/src/client/tcp.js
@@ -27,8 +27,6 @@ class TCPClient extends Client {
         this.writer = this.client;
         // start listeners, response handlers and error handlers
         this.listen();
-        this.handleResponse();
-        this.handleError();
         resolve(this.server);
       });
       let { retries } = this.options;
@@ -151,10 +149,6 @@ class TCPClient extends Client {
       this.on("batchResponse", (batch) => {
         const batchResponseIds = [];
         batch.forEach((message) => {
-          if (message.error) {
-            // reject the whole message if there are any errors
-            reject(batch);
-          }
           if (message.id) {
             batchResponseIds.push(message.id);
           }
@@ -166,6 +160,12 @@ class TCPClient extends Client {
           if (
             _.isEmpty(_.difference(JSON.parse(`[${ids}]`), batchResponseIds))
           ) {
+            batch.forEach((message) => {
+              if (message.error) {
+                // reject the whole message if there are any errors
+                this.pendingBatches[ids].reject(batch);
+              }
+            });
             this.pendingBatches[ids].resolve(batch);
           }
         }

--- a/src/server/http.js
+++ b/src/server/http.js
@@ -40,39 +40,36 @@ class HTTPServer extends Server {
                 const message = validationResult[1];
                 if (message.batch) {
                   this.setResponseHeader({ response });
-                  return response.write(
+                  response.write(
                     JSON.stringify(message.batch) + this.options.delimiter,
                     () => {
                       response.end();
                     }
                   );
-                }
-                if (message.notification) {
+                } else if (message.notification) {
                   this.setResponseHeader({ response, notification: true });
-                  return response.end();
-                }
-                this.getResult(message)
-                  .then((result) => {
-                    this.setResponseHeader({ response });
-                    return response.write(
-                      result + this.options.delimiter,
-                      () => {
+                  response.end();
+                } else {
+                  this.getResult(message)
+                    .then((result) => {
+                      this.setResponseHeader({ response });
+                      response.write(result + this.options.delimiter, () => {
                         response.end();
-                      }
-                    );
-                  })
-                  .catch((error) => {
-                    this.setResponseHeader({
-                      response,
-                      errorCode: error.error.code
+                      });
+                    })
+                    .catch((error) => {
+                      this.setResponseHeader({
+                        response,
+                        errorCode: error.error.code
+                      });
+                      response.write(
+                        JSON.stringify(error) + this.options.delimiter,
+                        () => {
+                          response.end();
+                        }
+                      );
                     });
-                    return response.write(
-                      JSON.stringify(error) + this.options.delimiter,
-                      () => {
-                        response.end();
-                      }
-                    );
-                  });
+                }
               })
               .catch((error) => {
                 this.setResponseHeader({

--- a/src/server/http.js
+++ b/src/server/http.js
@@ -33,80 +33,77 @@ class HTTPServer extends Server {
         request.on("end", () => {
           const messages = this.messageBuffer.split(this.options.delimiter);
           this.messageBuffer = "";
-          try {
-            messages
-              .filter(messageString => messageString !== "")
-              .map((chunk) => {
-                const validRequest = () => this.validateRequest(chunk)
-                  .then(result => result)
-                  .catch((error) => {
-                    throw new Error(JSON.stringify(error));
-                  });
-                return validRequest()
-                  .then((message) => {
-                    if (message.batch) {
-                      this.setResponseHeader({ response });
-                      return response.write(
-                        JSON.stringify(message.batch) + this.options.delimiter,
-                        () => {
-                          response.end();
-                        }
-                      );
-                    }
-                    if (message.notification) {
-                      this.setResponseHeader({ response, notification: true });
-                      return response.end();
-                    }
-                    this.getResult(message.json)
-                      .then((json) => {
-                        this.setResponseHeader({ response });
-                        return response.write(
-                          json + this.options.delimiter,
-                          () => {
-                            response.end();
-                          }
-                        );
-                      })
-                      .catch((error) => {
-                        this.setResponseHeader({
-                          response,
-                          errorCode: error.error.code
-                        });
-                        return response.write(
-                          JSON.stringify(error) + this.options.delimiter,
-                          () => {
-                            response.end();
-                          }
-                        );
-                      });
-                  })
-                  .catch((error) => {
-                    this.setResponseHeader({
-                      response,
-                      errorCode: JSON.parse(error.message).error.code
+          messages
+            .filter((messageString) => messageString !== "")
+            .map((chunk) => {
+              const validRequest = this.validateRequest(chunk)
+                .then((result) => result)
+                .catch((error) => {
+                  throw error;
+                });
+
+              const validMessage = validRequest
+                .then((result) => {
+                  return this._validateMessage(result)
+                    .then((message) => message)
+                    .catch((error) => {
+                      throw error;
                     });
-                    response.write(
-                      error.message + this.options.delimiter,
+                })
+                .catch((error) => {
+                  throw error;
+                });
+
+              return Promise.all([validRequest, validMessage])
+                .then(([_, message]) => {
+                  if (message.batch) {
+                    this.setResponseHeader({ response });
+                    return response.write(
+                      JSON.stringify(message.batch) + this.options.delimiter,
                       () => {
                         response.end();
                       }
                     );
+                  } else if (message.notification) {
+                    this.setResponseHeader({ response, notification: true });
+                    return response.end();
+                  }
+                  this.getResult(message)
+                    .then((result) => {
+                      this.setResponseHeader({ response });
+                      return response.write(
+                        result + this.options.delimiter,
+                        () => {
+                          response.end();
+                        }
+                      );
+                    })
+                    .catch((error) => {
+                      this.setResponseHeader({
+                        response,
+                        errorCode: error.error.code
+                      });
+                      return response.write(
+                        JSON.stringify(error) + this.options.delimiter,
+                        () => {
+                          response.end();
+                        }
+                      );
+                    });
+                })
+                .catch((error) => {
+                  this.setResponseHeader({
+                    response,
+                    errorCode: error.code
                   });
-              });
-          } catch (e) {
-            const error = this.sendError(
-              null,
-              ERR_CODES.parseError,
-              ERR_MSGS.parseError
-            );
-            this.setResponseHeader({ response, errorCode: error.code });
-            return response.write(
-              JSON.stringify(error) + this.options.delimiter,
-              () => {
-                response.end();
-              }
-            );
-          }
+                  response.write(
+                    JSON.stringify(error) + this.options.delimiter,
+                    () => {
+                      response.end();
+                    }
+                  );
+                });
+            });
         });
       });
       client.on("close", () => {
@@ -145,7 +142,7 @@ class HTTPServer extends Server {
 
   clientDisconnected(cb) {
     this.on("clientDisconnected", (client) => {
-      const clientIndex = this.connectedClients.findIndex(c => client === c);
+      const clientIndex = this.connectedClients.findIndex((c) => client === c);
       if (clientIndex === -1) {
         return "unknown";
       }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -101,11 +101,15 @@ class Server extends EventEmitter {
     return new Promise((resolve, reject) => {
       try {
         const requests = batch;
-        const batchRequests = requests.map(request => this.validateRequest(request)
-          .then(message => this.getResult(message.json)
-            .then(result => JSON.parse(result))
-            .catch(error => error))
-          .catch(error => error));
+        const batchRequests = requests.map((request) =>
+          this._validateMessage(request)
+            .then((message) =>
+              this.getResult(message)
+                .then((result) => JSON.parse(result))
+                .catch((error) => error)
+            )
+            .catch((error) => error)
+        );
         Promise.all(batchRequests)
           .then((result) => {
             resolve(result);
@@ -123,95 +127,97 @@ class Server extends EventEmitter {
     });
   }
 
-  validateRequest(message) {
+  validateRequest(request) {
     return new Promise((resolve, reject) => {
       try {
-        let json = message;
-        // only parse if message isnt json object
-        if (!_.isObject(json)) {
-          json = JSON.parse(message);
-        }
-        if (_.isArray(json)) {
-          // possible batch request
-          if (_.isEmpty(json)) {
-            const error = this.sendError(
-              null,
-              ERR_CODES.invalidRequest,
-              ERR_MSGS.invalidRequest
-            );
-            return reject(error);
-          }
-          return this.handleBatchRequest(json)
-            .then((responses) => {
-              resolve({ batch: responses });
-            })
-            .catch((error) => {
-              reject(JSON.stringify(error));
-            });
-        }
-
-        if (!_.isObject(json)) {
-          reject(
-            this.sendError(
-              null,
-              ERR_CODES.invalidRequest,
-              ERR_MSGS.invalidRequest
-            )
-          );
-        }
-
-        if (!json.id) {
-          // no id, so assume notification
-          this.emit("notify", json);
-          resolve({ notification: json });
-        }
-
-        if (!_.isString(json.method)) {
-          reject(
-            this.sendError(
-              json.id,
-              ERR_CODES.invalidRequest,
-              ERR_MSGS.invalidRequest
-            )
-          );
-        }
-
-        if (json.jsonrpc) {
-          if (this.options.version !== "2.0") {
-            reject(
-              this.sendError(
-                json.id,
-                ERR_CODES.invalidRequest,
-                ERR_MSGS.invalidRequest
-              )
-            );
-          }
-        }
-
-        if (!this.methods[json.method]) {
-          reject(
-            this.sendError(
-              json.id,
-              ERR_CODES.methodNotFound,
-              ERR_MSGS.methodNotFound
-            )
-          );
-        }
-
-        if (!isArray(json.params) && !isObject(json.params)) {
-          reject(
-            this.sendError(
-              json.id,
-              ERR_CODES.invalidParams,
-              ERR_MSGS.invalidParams
-            )
-          );
-        }
-        // data looks good
-        resolve({ json });
+        const message = JSON.parse(request);
+        resolve(message);
       } catch (e) {
         reject(this.sendError(null, ERR_CODES.parseError, ERR_MSGS.parseError));
       }
+    });
+  }
+
+  _validateMessage(message) {
+    return new Promise((resolve, reject) => {
+      if (_.isArray(message)) {
+        // possible batch request
+        if (_.isEmpty(message)) {
+          const error = this.sendError(
+            null,
+            ERR_CODES.invalidRequest,
+            ERR_MSGS.invalidRequest
+          );
+          return reject(error);
+        }
+        return this.handleBatchRequest(message)
+          .then((responses) => {
+            resolve({ batch: responses });
+          })
+          .catch((error) => {
+            reject(JSON.stringify(error));
+          });
+      }
+
+      if (!_.isObject(message)) {
+        reject(
+          this.sendError(
+            null,
+            ERR_CODES.invalidRequest,
+            ERR_MSGS.invalidRequest
+          )
+        );
+      }
+
+      if (!message.id) {
+        // no id, so assume notification
+        this.emit("notify", message);
+        resolve({ notification: message });
+      }
+
+      if (!_.isString(message.method)) {
+        reject(
+          this.sendError(
+            message.id,
+            ERR_CODES.invalidRequest,
+            ERR_MSGS.invalidRequest
+          )
+        );
+      }
+
+      if (message.jsonrpc) {
+        if (this.options.version !== "2.0") {
+          reject(
+            this.sendError(
+              message.id,
+              ERR_CODES.invalidRequest,
+              ERR_MSGS.invalidRequest
+            )
+          );
+        }
+      }
+
+      if (!this.methods[message.method]) {
+        reject(
+          this.sendError(
+            message.id,
+            ERR_CODES.methodNotFound,
+            ERR_MSGS.methodNotFound
+          )
+        );
+      }
+
+      if (!isArray(message.params) && !isObject(message.params)) {
+        reject(
+          this.sendError(
+            message.id,
+            ERR_CODES.invalidParams,
+            ERR_MSGS.invalidParams
+          )
+        );
+      }
+      // data looks good
+      resolve(message);
     });
   }
 

--- a/src/server/tcp.js
+++ b/src/server/tcp.js
@@ -64,10 +64,12 @@ class TCPServer extends Server {
   }
 
   clientConnected(cb) {
-    this.on("clientConnected", client => cb({
-      host: client.remoteAddress,
-      port: client.remotePort
-    }));
+    this.on("clientConnected", (client) => {
+      cb({
+        host: client.remoteAddress,
+        port: client.remotePort
+      });
+    });
   }
 
   clientDisconnected(cb) {

--- a/tests/client/http-client.test.js
+++ b/tests/client/http-client.test.js
@@ -129,6 +129,47 @@ describe("HTTP Client", () => {
       });
     });
   });
+  describe("multiple requests", () => {
+    it("should get responses for multiple requests at once", (done) => {
+      const request = clienthttp.request().send("add", [1, 2]);
+      const request2 = clienthttp.request().send("greeting", { name: "Isaac" });
+      const request3 = clienthttp.batch([
+        clienthttp.request().message("add", [1, 2]),
+        clienthttp.request().message("add", [3, 4])
+      ]);
+      const request4 = clienthttp.batch([
+        clienthttp.request().message("nonexistent", [1, 2]),
+        clienthttp.request().message("add", [3, 4])
+      ]);
+      request.then((res1) => {
+        expect(res1.body).to.eql({ jsonrpc: "2.0", result: 3, id: 10 });
+        request2.then((res2) => {
+          expect(res2.body).to.eql({
+            jsonrpc: "2.0",
+            result: "Hello Isaac",
+            id: 11
+          });
+          request3.then((res3) => {
+            expect(res3).to.eql([
+              { result: 3, jsonrpc: "2.0", id: 12 },
+              { result: 7, jsonrpc: "2.0", id: 13 }
+            ]);
+            request4.catch((res4) => {
+              expect(res4).to.eql([
+                {
+                  jsonrpc: "2.0",
+                  error: { code: -32601, message: "Method not found" },
+                  id: 14
+                },
+                { result: 7, jsonrpc: "2.0", id: 15 }
+              ]);
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
   describe("notifications", () => {
     it("should receive a '204' response for a notification", (done) => {
       const request = clienthttp.request().notify("notify", []);

--- a/tests/client/http-client.test.js
+++ b/tests/client/http-client.test.js
@@ -57,13 +57,6 @@ describe("HTTP Client", () => {
         done();
       });
     });
-    it("should receive a '204' response for a notification", (done) => {
-      const request = clienthttp.request().notify("notify", []);
-      request.then((response) => {
-        expect(response.statusCode).to.be.equal(204);
-        done();
-      });
-    });
     it("should get an 'invalid params' error", (done) => {
       const request = clienthttp.request().send("add", {});
       request.catch((response) => {
@@ -92,6 +85,19 @@ describe("HTTP Client", () => {
         done();
       });
     });
+    it("should get a response for large dataset", (done) => {
+      const request = clienthttp.request().send("large.data", []);
+      request.then((response) => {
+        expect(response.body).to.be.eql({
+          result: data,
+          jsonrpc: "2.0",
+          id: 5
+        });
+        done();
+      });
+    });
+  });
+  describe("batches", () => {
     it("should receive response for batch request", (done) => {
       const request = clienthttp.batch([
         clienthttp.request().message("add", [1, 2]),
@@ -99,20 +105,9 @@ describe("HTTP Client", () => {
       ]);
       request.then((response) => {
         expect(response).to.eql([
-          { result: 3, jsonrpc: "2.0", id: 5 },
-          { result: 7, jsonrpc: "2.0", id: 6 }
+          { result: 3, jsonrpc: "2.0", id: 6 },
+          { result: 7, jsonrpc: "2.0", id: 7 }
         ]);
-        done();
-      });
-    });
-    it("should get a response for large dataset", (done) => {
-      const request = clienthttp.request().send("large.data", []);
-      request.then((response) => {
-        expect(response.body).to.be.eql({
-          result: data,
-          jsonrpc: "2.0",
-          id: 7
-        });
         done();
       });
     });
@@ -121,7 +116,7 @@ describe("HTTP Client", () => {
         clienthttp.request().message("nonexistent", [1, 2]),
         clienthttp.request().message("add", [3, 4])
       ]);
-      request.then((response) => {
+      request.catch((response) => {
         expect(response).to.eql([
           {
             jsonrpc: "2.0",
@@ -130,6 +125,15 @@ describe("HTTP Client", () => {
           },
           { result: 7, jsonrpc: "2.0", id: 9 }
         ]);
+        done();
+      });
+    });
+  });
+  describe("notifications", () => {
+    it("should receive a '204' response for a notification", (done) => {
+      const request = clienthttp.request().notify("notify", []);
+      request.then((response) => {
+        expect(response.statusCode).to.be.equal(204);
         done();
       });
     });

--- a/tests/client/http-client.test.js
+++ b/tests/client/http-client.test.js
@@ -104,7 +104,7 @@ describe("HTTP Client", () => {
         clienthttp.request().message("add", [3, 4])
       ]);
       request.then((response) => {
-        expect(response).to.eql([
+        expect(response.body).to.eql([
           { result: 3, jsonrpc: "2.0", id: 6 },
           { result: 7, jsonrpc: "2.0", id: 7 }
         ]);
@@ -117,7 +117,7 @@ describe("HTTP Client", () => {
         clienthttp.request().message("add", [3, 4])
       ]);
       request.catch((response) => {
-        expect(response).to.eql([
+        expect(response.body).to.eql([
           {
             jsonrpc: "2.0",
             error: { code: -32601, message: "Method not found" },
@@ -150,12 +150,12 @@ describe("HTTP Client", () => {
             id: 11
           });
           request3.then((res3) => {
-            expect(res3).to.eql([
+            expect(res3.body).to.eql([
               { result: 3, jsonrpc: "2.0", id: 12 },
               { result: 7, jsonrpc: "2.0", id: 13 }
             ]);
             request4.catch((res4) => {
-              expect(res4).to.eql([
+              expect(res4.body).to.eql([
                 {
                   jsonrpc: "2.0",
                   error: { code: -32601, message: "Method not found" },

--- a/tests/client/tcp-client.test.js
+++ b/tests/client/tcp-client.test.js
@@ -101,56 +101,13 @@ describe("TCP Client", () => {
         done();
       });
     });
-    it("should receive response for batch request", (done) => {
-      const request = client.batch([
-        client.request().message("add", [1, 2]),
-        client.request().message("add", [3, 4])
-      ]);
-      request.then((response) => {
-        expect(response).to.eql([
-          { result: 3, jsonrpc: "2.0", id: 3 },
-          { result: 7, jsonrpc: "2.0", id: 4 }
-        ]);
-        done();
-      });
-    });
-    it("should receive error in batch response if one batch request is bad", (done) => {
-      const request = client.batch([
-        client.request().message("nonexistent", [1, 2]),
-        client.request().message("add", [3, 4])
-      ]);
-      request.then((response) => {
-        expect(response).to.eql([
-          {
-            jsonrpc: "2.0",
-            error: { code: -32601, message: "Method not found" },
-            id: 5
-          },
-          { result: 7, jsonrpc: "2.0", id: 6 }
-        ]);
-        done();
-      });
-    });
-    // it("should receive 'invalid request' error for non empty array", (done) => {
-    //   const request = client.batch([1]);
-    //   request.catch((response) => {
-    //     expect(response).to.eql([
-    //       {
-    //         jsonrpc: "2.0",
-    //         error: { code: -32600, message: "Invalid Request" },
-    //         id: null
-    //       }
-    //     ]);
-    //     done();
-    //   });
-    // });
     it("should handle 'method not found' error", (done) => {
       const request = client.request().send("nonexistent method", []);
       request.catch((error) => {
         expect(error).to.eql({
           jsonrpc: "2.0",
           error: { code: -32601, message: "Method not found" },
-          id: 7
+          id: 3
         });
         done();
       });
@@ -161,7 +118,7 @@ describe("TCP Client", () => {
         expect(error).to.eql({
           jsonrpc: "2.0",
           error: { code: -32602, message: "Invalid Parameters" },
-          id: 8
+          id: 4
         });
         done();
       });
@@ -172,8 +129,53 @@ describe("TCP Client", () => {
         expect(result).to.eql({
           jsonrpc: "2.0",
           result: data,
-          id: 9
+          id: 5
         });
+        done();
+      });
+    });
+  });
+  describe("batches", () => {
+    it("should receive response for batch request", (done) => {
+      const request = client.batch([
+        client.request().message("add", [1, 2]),
+        client.request().message("add", [3, 4])
+      ]);
+      request.then((response) => {
+        expect(response).to.eql([
+          { result: 3, jsonrpc: "2.0", id: 6 },
+          { result: 7, jsonrpc: "2.0", id: 7 }
+        ]);
+        done();
+      });
+    });
+    it("should receive error in batch response if one batch request is bad", (done) => {
+      const request = client.batch([
+        client.request().message("nonexistent", [1, 2]),
+        client.request().message("add", [3, 4])
+      ]);
+      request.catch((response) => {
+        expect(response).to.eql([
+          {
+            jsonrpc: "2.0",
+            error: { code: -32601, message: "Method not found" },
+            id: 8
+          },
+          { result: 7, jsonrpc: "2.0", id: 9 }
+        ]);
+        done();
+      });
+    });
+    it("should receive 'invalid request' error for non empty array", (done) => {
+      const request = client.batch([1]);
+      request.catch((response) => {
+        expect(response).to.eql([
+          {
+            jsonrpc: "2.0",
+            error: { code: -32600, message: "Invalid Request" },
+            id: null
+          }
+        ]);
         done();
       });
     });

--- a/tests/server/tcp-server.test.js
+++ b/tests/server/tcp-server.test.js
@@ -175,5 +175,19 @@ describe("TCP Server", () => {
       });
       client.request().notify("notification", []);
     });
+    // it("should handle batch notifications", (done) => {
+    //   server.onNotify("notification", (error, message) => {
+    //     if (error) {
+    //       return done(error);
+    //     }
+    //     expect(message).to.be.eql({
+    //       jsonrpc: "2.0",
+    //       method: "notification",
+    //       params: []
+    //     });
+    //     done();
+    //   });
+    //   client.batch([client.request().message("notification", [], false)]);
+    // });
   });
 });


### PR DESCRIPTION
Rejects stringified batch objects.
Client and server message validation code improvements. Refs #17 .
Remove this.server.on('connection') wrapper around data, which fixes duplicate http requests.
Handle multiple concurrent requests from TCP and HTTP client.
Use response.body for http batch responses, mirrors regular request.
Add id option to request().message to allow for notification messages.
Organize tests better.

Still unable to handle batch notifications.