### PR TITLE
Make sure message buffer has whole messages before attempting to parse

### DIFF
--- a/src/client/http.js
+++ b/src/client/http.js
@@ -139,7 +139,7 @@ class HTTPClient extends Client {
       }
       this.pendingBatches[String(batchIds)] = { resolve, reject };
 
-      const request = JSON.stringify(batchRequests);
+      const request = JSON.stringify(batchRequests) + this.options.delimiter;
       this.options.headers["Content-Length"] = Buffer.byteLength(
         request,
         this.options.encoding

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -192,7 +192,7 @@ class Client extends EventEmitter {
         });
       } else {
         const messages = this.messageBuffer.split(this.options.delimiter);
-        if (messages.length > 1) {
+        if (messages.length > 1 && messages[messages.length - 1] === "") {
           // otherwise messages are still coming in and request
           // possibly hasnt finished
           this.messageBuffer = "";

--- a/src/client/ws.js
+++ b/src/client/ws.js
@@ -114,60 +114,62 @@ class WSClient extends Client {
     };
   }
 
-  verifyData(chunk) {
-    try {
-      // sometimes split messages have empty string at the end
-      // just ignore it
-      if (chunk !== "") {
-        // will throw an error if not valid json
-        const message = JSON.parse(chunk);
-        if (_.isArray(message)) {
-          // possible batch request
-          this.handleBatchResponse(message);
-        } else if (!_.isObject(message)) {
-          // error out if it cant be parsed
-          const error = this.sendError({
-            id: null,
-            code: ERR_CODES.parseError,
-            message: ERR_MSGS.parseError
-          });
-          this.handleError(error);
-        } else if (!message.id) {
-          // no id, so assume notification
-          this.handleNotification(message);
-        } else if (message.error) {
-          // got an error back so reject the message
-          const error = this.sendError({
-            jsonrpc: message.jsonrpc,
-            id: message.id,
-            code: message.error.code,
-            message: message.error.message
-          });
-          this.handleError(error);
-        } else if (!message.method) {
-          // no method, so assume response
-          this.serving_message_id = message.id;
-          this.responseQueue[this.serving_message_id] = message;
-          this.handleResponse(message);
-        } else {
-          throw new Error();
+  verifyData(messages) {
+    for (const chunk of messages) {
+      try {
+        // sometimes split messages have empty string at the end
+        // just ignore it
+        if (chunk !== "") {
+          // will throw an error if not valid json
+          const message = JSON.parse(chunk);
+          if (_.isArray(message)) {
+            // possible batch request
+            this.handleBatchResponse(message);
+          } else if (!_.isObject(message)) {
+            // error out if it cant be parsed
+            const error = this.sendError({
+              id: null,
+              code: ERR_CODES.parseError,
+              message: ERR_MSGS.parseError
+            });
+            this.handleError(error);
+          } else if (!message.id) {
+            // no id, so assume notification
+            this.handleNotification(message);
+          } else if (message.error) {
+            // got an error back so reject the message
+            const error = this.sendError({
+              jsonrpc: message.jsonrpc,
+              id: message.id,
+              code: message.error.code,
+              message: message.error.message
+            });
+            this.handleError(error);
+          } else if (!message.method) {
+            // no method, so assume response
+            this.serving_message_id = message.id;
+            this.responseQueue[this.serving_message_id] = message;
+            this.handleResponse(message);
+          } else {
+            throw new Error();
+          }
         }
-      }
-    } catch (e) {
-      if (e instanceof SyntaxError) {
-        const error = this.sendError({
-          id: this.serving_message_id,
-          code: ERR_CODES.parseError,
-          message: `Unable to parse message: '${chunk}'`
-        });
-        this.handleError(error);
-      } else {
-        const error = this.sendError({
-          id: this.serving_message_id,
-          code: ERR_CODES.internal,
-          message: `Unable to parse message: '${chunk}'`
-        });
-        this.handleError(error);
+      } catch (e) {
+        if (e instanceof SyntaxError) {
+          const error = this.sendError({
+            id: this.serving_message_id,
+            code: ERR_CODES.parseError,
+            message: `Unable to parse message: '${chunk}'`
+          });
+          this.handleError(error);
+        } else {
+          const error = this.sendError({
+            id: this.serving_message_id,
+            code: ERR_CODES.internal,
+            message: `Unable to parse message: '${chunk}'`
+          });
+          this.handleError(error);
+        }
       }
     }
   }
@@ -265,7 +267,12 @@ class WSClient extends Client {
 
   listen() {
     this.client.onmessage = (message) => {
-      this.verifyData(message.data);
+      this.messageBuffer += message.data;
+      const messages = this.messageBuffer.split(this.options.delimiter);
+      if (messages.length > 1 && messages[messages.length - 1] === "") {
+        this.messageBuffer = "";
+        this.verifyData(messages);
+      }
     };
   }
 

--- a/tests/client/ws-client-node.test.js
+++ b/tests/client/ws-client-node.test.js
@@ -91,8 +91,7 @@ describe("WebSocket Node Client", () => {
               jsonrpc: "2.0",
               error: {
                 code: -32700,
-                message:
-                  "Unable to parse message: 'should get a parse error\r\n'"
+                message: "Unable to parse message: 'should get a parse error\r'"
               },
               id: 1
             });
@@ -115,7 +114,7 @@ describe("WebSocket Node Client", () => {
         setTimeout(() => {
           unhook();
           expect(capturedText).to.equal(
-            "Message has no outstanding calls: {\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32700,\"message\":\"Unable to parse message: 'should get a parse error\\r\\n'\"},\"id\":1}\n"
+            "Message has no outstanding calls: {\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32700,\"message\":\"Unable to parse message: 'should get a parse error\\r'\"},\"id\":1}\n"
           );
           done();
         }, 100);

--- a/tests/client/ws-client.test.js
+++ b/tests/client/ws-client.test.js
@@ -93,8 +93,7 @@ describe("WebSocket Client", () => {
               jsonrpc: "2.0",
               error: {
                 code: -32700,
-                message:
-                  "Unable to parse message: 'should get a parse error\r\n'"
+                message: "Unable to parse message: 'should get a parse error\r'"
               },
               id: 1
             });
@@ -117,7 +116,7 @@ describe("WebSocket Client", () => {
         setTimeout(() => {
           unhook();
           expect(capturedText).to.equal(
-            "Message has no outstanding calls: {\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32700,\"message\":\"Unable to parse message: 'should get a parse error\\r\\n'\"},\"id\":1}\n"
+            "Message has no outstanding calls: {\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32700,\"message\":\"Unable to parse message: 'should get a parse error\\r'\"},\"id\":1}\n"
           );
           done();
         }, 100);


### PR DESCRIPTION
Ensure message buffer contains whole messages before attempting to parse. Refs #27.
Add delimiter to http batch requests.