### PR TITLE
Bugfix/#36/server cant handle multiple connections

### DIFF
--- a/src/ServerProtocol.js
+++ b/src/ServerProtocol.js
@@ -1,0 +1,81 @@
+const { MessageBuffer } = require("./buffer");
+
+class TCPServerProtocol {
+  constructor(client, delimiter) {
+    this.client = client;
+    this.factory = null;
+    this.delimiter = delimiter;
+    this.messageBuffer = new MessageBuffer(delimiter);
+  }
+
+  clientConnected() {
+    this.client.on("data", (data) => {
+      this.messageBuffer.push(data);
+      while (!this.messageBuffer.isFinished()) {
+        const chunk = this.messageBuffer.handleData();
+        Promise.all(this.factory.handleValidation(chunk))
+          .then((validationResult) => {
+            const message = validationResult[1];
+            if (message.batch) {
+              this.client.write(JSON.stringify(message.batch) + this.delimiter);
+            } else if (message.notification) {
+              this.factory.emit("notify", message.notification);
+            } else {
+              this.factory
+                .getResult(message)
+                .then(result => this.client.write(result + this.delimiter))
+                .catch(error => this.client.write(JSON.stringify(error) + this.delimiter));
+            }
+          })
+          .catch(error => this.client.write(JSON.stringify(error) + this.delimiter));
+      }
+    });
+    this.client.on("close", () => {
+      this.factory.emit("clientDisconnected", this.client);
+    });
+    this.client.on("end", () => {
+      this.factory.emit("clientDisconnected", this.client);
+    });
+  }
+}
+
+class WSServerProtocol {
+  constructor(client, delimiter) {
+    this.client = client;
+    this.factory = null;
+    this.delimiter = delimiter;
+    this.messageBuffer = new MessageBuffer(delimiter);
+  }
+
+  clientConnected() {
+    this.client.on("message", (data) => {
+      this.messageBuffer.push(data);
+      while (!this.messageBuffer.isFinished()) {
+        const chunk = this.messageBuffer.handleData();
+        Promise.all(this.factory.handleValidation(chunk))
+          .then((validationResult) => {
+            const message = validationResult[1];
+            if (message.batch) {
+              this.client.send(JSON.stringify(message.batch) + this.delimiter);
+            } else if (message.notification) {
+              this.factory.emit("notify", message.notification);
+            } else {
+              this.factory
+                .getResult(message)
+                .then(result => this.client.send(result + this.delimiter))
+                .catch(error => this.client.send(JSON.stringify(error) + this.delimiter));
+            }
+          })
+          .catch(error => this.client.send(JSON.stringify(error) + this.delimiter));
+      }
+    });
+    this.client.on("close", () => {
+      this.factory.emit("clientDisconnected", this.client);
+    });
+    this.client.on("end", () => {
+      this.factory.emit("clientDisconnected", this.client);
+    });
+  }
+}
+
+module.exports = { TCPServerProtocol, WSServerProtocol };

--- a/src/server/http.js
+++ b/src/server/http.js
@@ -1,7 +1,7 @@
 const http = require("http");
 const Server = require(".");
 const { errorToStatus } = require("../constants");
-const { MessageBuffer } = require("../buffer");
+const { HttpServerProtocol } = require("../ServerProtocol");
 
 /**
  * Constructor for Jsonic HTTP server
@@ -23,7 +23,6 @@ class HTTPServer extends Server {
   initserver() {
     this.server = new http.Server();
     this.server.on("connection", (client) => {
-      this.messageBuffer = new MessageBuffer(this.options.delimiter);
       this.connectedClients.push(client);
       client.on("close", () => {
         this.emit("clientDisconnected");
@@ -36,62 +35,13 @@ class HTTPServer extends Server {
 
   handleData() {
     this.server.on("request", (request, response) => {
-      request.on("data", (data) => {
-        this.messageBuffer.push(data);
-      });
-      request.on("end", () => {
-        while (!this.messageBuffer.isFinished()) {
-          const chunk = this.messageBuffer.handleData();
-          Promise.all(this.handleValidation(chunk))
-            .then((validationResult) => {
-              const message = validationResult[1];
-              if (message.batch) {
-                this.setResponseHeader({ response });
-                response.write(
-                  JSON.stringify(message.batch) + this.options.delimiter,
-                  () => {
-                    response.end();
-                  }
-                );
-              } else if (message.notification) {
-                this.setResponseHeader({ response, notification: true });
-                response.end();
-              } else {
-                this.getResult(message)
-                  .then((result) => {
-                    this.setResponseHeader({ response });
-                    response.write(result + this.options.delimiter, () => {
-                      response.end();
-                    });
-                  })
-                  .catch((error) => {
-                    this.setResponseHeader({
-                      response,
-                      errorCode: error.error.code
-                    });
-                    response.write(
-                      JSON.stringify(error) + this.options.delimiter,
-                      () => {
-                        response.end();
-                      }
-                    );
-                  });
-              }
-            })
-            .catch((error) => {
-              this.setResponseHeader({
-                response,
-                errorCode: error.code
-              });
-              response.write(
-                JSON.stringify(error) + this.options.delimiter,
-                () => {
-                  response.end();
-                }
-              );
-            });
-        }
-      });
+      const httpProtocol = new HttpServerProtocol(
+        request,
+        response,
+        this.options.delimiter
+      );
+      httpProtocol.factory = this;
+      httpProtocol.clientConnected();
     });
   }
 

--- a/src/server/http.js
+++ b/src/server/http.js
@@ -1,6 +1,7 @@
 const http = require("http");
 const Server = require(".");
 const { errorToStatus } = require("../constants");
+const { MessageBuffer } = require("../buffer");
 
 /**
  * Constructor for Jsonic HTTP server
@@ -22,6 +23,7 @@ class HTTPServer extends Server {
   initserver() {
     this.server = new http.Server();
     this.server.on("connection", (client) => {
+      this.messageBuffer = new MessageBuffer(this.options.delimiter);
       this.connectedClients.push(client);
       client.on("close", () => {
         this.emit("clientDisconnected");

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,7 +1,6 @@
 const EventEmitter = require("events");
 const { formatResponse } = require("../functions");
 const { ERR_CODES, ERR_MSGS } = require("../constants");
-const { MessageBuffer } = require("../buffer");
 
 /**
  * @class Server
@@ -33,7 +32,7 @@ class Server extends EventEmitter {
       ...defaults,
       ...(options || {})
     };
-    this.messageBuffer = new MessageBuffer(this.options.delimiter);
+
     this.methods = {};
     this.listening = false;
   }

--- a/src/server/tcp.js
+++ b/src/server/tcp.js
@@ -1,6 +1,7 @@
 const net = require("net");
 const Server = require(".");
 const { formatResponse } = require("../functions");
+const { MessageBuffer } = require("../buffer");
 
 /**
  * Constructor for Jsonic TCP client
@@ -25,6 +26,7 @@ class TCPServer extends Server {
 
   handleData() {
     this.server.on("connection", (client) => {
+      this.messageBuffer = new MessageBuffer(this.options.delimiter);
       this.connectedClients.push(client);
       this.emit("clientConnected", client);
       client.on("data", (data) => {

--- a/src/server/ws.js
+++ b/src/server/ws.js
@@ -1,7 +1,7 @@
 const WebSocket = require("ws");
 const Server = require(".");
 const { formatResponse } = require("../functions");
-const { MessageBuffer } = require("../buffer");
+const { WSServerProtocol } = require("../ServerProtocol");
 
 /**
  * Constructor for Jsonic WS client
@@ -59,37 +59,14 @@ class WSServer extends Server {
 
   handleData() {
     this.server.on("connection", (client) => {
-      this.messageBuffer = new MessageBuffer(this.options.delimiter);
       this.emit("clientConnected", client);
       this.connectedClients.push(client);
-      client.on("message", (data) => {
-        this.messageBuffer.push(data);
-        while (!this.messageBuffer.isFinished()) {
-          const chunk = this.messageBuffer.handleData();
-          Promise.all(this.handleValidation(chunk))
-            .then((validationResult) => {
-              const message = validationResult[1];
-              if (message.batch) {
-                client.send(
-                  JSON.stringify(message.batch) + this.options.delimiter
-                );
-              } else if (message.notification) {
-                this.emit("notify", message.notification);
-              } else {
-                this.getResult(message)
-                  .then(result => client.send(result + this.options.delimiter))
-                  .catch(error => client.send(JSON.stringify(error) + this.options.delimiter));
-              }
-            })
-            .catch(error => client.send(JSON.stringify(error) + this.options.delimiter));
-        }
-      });
-      client.on("close", () => {
-        this.emit("clientDisconnected", client);
-      });
-      client.on("end", () => {
-        this.emit("clientDisconnected", client);
-      });
+      const wsServerProtocol = new WSServerProtocol(
+        client,
+        this.options.delimiter
+      );
+      wsServerProtocol.factory = this;
+      wsServerProtocol.clientConnected();
     });
   }
 

--- a/src/server/ws.js
+++ b/src/server/ws.js
@@ -1,6 +1,7 @@
 const WebSocket = require("ws");
 const Server = require(".");
 const { formatResponse } = require("../functions");
+const { MessageBuffer } = require("../buffer");
 
 /**
  * Constructor for Jsonic WS client
@@ -58,6 +59,7 @@ class WSServer extends Server {
 
   handleData() {
     this.server.on("connection", (client) => {
+      this.messageBuffer = new MessageBuffer(this.options.delimiter);
       this.emit("clientConnected", client);
       this.connectedClients.push(client);
       client.on("message", (data) => {

--- a/tests/server/http-server.test.js
+++ b/tests/server/http-server.test.js
@@ -51,7 +51,7 @@ describe("HTTP Server", () => {
       const client1 = new Jaysonic.client.http({ port: 8000 });
       const client2 = new Jaysonic.client.http({ port: 8000 });
       const req1 = client1.request().send("add", [1, 2]);
-      const req2 = client2.request().send("add", [1, 2]);
+      const req2 = client2.request().send("greeting", { name: "Isaac" });
       Promise.all([req1, req2]).then((results) => {
         const [res1, res2] = results;
         expect(res1.body).to.eql({
@@ -61,7 +61,7 @@ describe("HTTP Server", () => {
         });
         expect(res2.body).to.eql({
           jsonrpc: "2.0",
-          result: 3,
+          result: "Hello Isaac",
           id: 1
         });
         done();

--- a/tests/server/http-server.test.js
+++ b/tests/server/http-server.test.js
@@ -2,10 +2,10 @@ const { expect } = require("chai");
 const chai = require("chai");
 const chaiHttp = require("chai-http");
 
-const Jayson = require("../../src");
+const Jaysonic = require("../../src");
 
-const server = new Jayson.server.http({ port: 8000 });
-const serverV1 = new Jayson.server.http({ port: 8400, version: 1 });
+const server = new Jaysonic.server.http({ port: 8000 });
+const serverV1 = new Jaysonic.server.http({ port: 8400, version: 1 });
 const { clienthttp } = require("../test-client");
 
 chai.use(chaiHttp);
@@ -44,6 +44,26 @@ describe("HTTP Server", () => {
       const conn = server.listen();
       conn.catch((error) => {
         expect(error.message).to.be.a("string");
+        done();
+      });
+    });
+    it("should handle requests from multiple clients", (done) => {
+      const client1 = new Jaysonic.client.http({ port: 8000 });
+      const client2 = new Jaysonic.client.http({ port: 8000 });
+      const req1 = client1.request().send("add", [1, 2]);
+      const req2 = client2.request().send("add", [1, 2]);
+      Promise.all([req1, req2]).then((results) => {
+        const [res1, res2] = results;
+        expect(res1.body).to.eql({
+          jsonrpc: "2.0",
+          result: 3,
+          id: 1
+        });
+        expect(res2.body).to.eql({
+          jsonrpc: "2.0",
+          result: 3,
+          id: 1
+        });
         done();
       });
     });

--- a/tests/server/tcp-server.test.js
+++ b/tests/server/tcp-server.test.js
@@ -59,6 +59,30 @@ describe("TCP Server", () => {
         done();
       });
     });
+    it("should handle requests from multiple clients", (done) => {
+      const client1 = new Jaysonic.client.tcp({ port: 6969 });
+      const client2 = new Jaysonic.client.tcp({ port: 6969 });
+      client1.connect().then(() => {
+        client2.connect().then(() => {
+          const req1 = client1.request().send("add", [1, 2]);
+          const req2 = client2.request().send("add", [1, 2]);
+          Promise.all([req1, req2]).then((results) => {
+            const [res1, res2] = results;
+            expect(res1).to.eql({
+              jsonrpc: "2.0",
+              result: 3,
+              id: 1
+            });
+            expect(res2).to.eql({
+              jsonrpc: "2.0",
+              result: 3,
+              id: 1
+            });
+            done();
+          });
+        });
+      });
+    });
   });
   describe("requests", () => {
     it("should handle call with positional params", (done) => {

--- a/tests/server/tcp-server.test.js
+++ b/tests/server/tcp-server.test.js
@@ -65,7 +65,7 @@ describe("TCP Server", () => {
       client1.connect().then(() => {
         client2.connect().then(() => {
           const req1 = client1.request().send("add", [1, 2]);
-          const req2 = client2.request().send("add", [1, 2]);
+          const req2 = client2.request().send("greeting", { name: "Isaac" });
           Promise.all([req1, req2]).then((results) => {
             const [res1, res2] = results;
             expect(res1).to.eql({
@@ -75,7 +75,7 @@ describe("TCP Server", () => {
             });
             expect(res2).to.eql({
               jsonrpc: "2.0",
-              result: 3,
+              result: "Hello Isaac",
               id: 1
             });
             done();

--- a/tests/server/ws-server.test.js
+++ b/tests/server/ws-server.test.js
@@ -28,6 +28,30 @@ describe("WebSocket Server", () => {
         done();
       });
     });
+    it("should handle requests from multiple clients", (done) => {
+      const client1 = new Jaysonic.client.ws({ url: "ws://127.0.0.1:9000" });
+      const client2 = new Jaysonic.client.ws({ url: "ws://127.0.0.1:9000" });
+      client1.connect().then(() => {
+        client2.connect().then(() => {
+          const req1 = client1.request().send("add", [1, 2]);
+          const req2 = client2.request().send("add", [1, 2]);
+          Promise.all([req1, req2]).then((results) => {
+            const [res1, res2] = results;
+            expect(res1).to.eql({
+              jsonrpc: "2.0",
+              result: 3,
+              id: 1
+            });
+            expect(res2).to.eql({
+              jsonrpc: "2.0",
+              result: 3,
+              id: 1
+            });
+            done();
+          });
+        });
+      });
+    });
   });
   describe("requests", () => {
     it("should handle call with positional params", (done) => {

--- a/tests/server/ws-server.test.js
+++ b/tests/server/ws-server.test.js
@@ -34,7 +34,7 @@ describe("WebSocket Server", () => {
       client1.connect().then(() => {
         client2.connect().then(() => {
           const req1 = client1.request().send("add", [1, 2]);
-          const req2 = client2.request().send("add", [1, 2]);
+          const req2 = client2.request().send("greeting", { name: "Isaac" });
           Promise.all([req1, req2]).then((results) => {
             const [res1, res2] = results;
             expect(res1).to.eql({
@@ -44,7 +44,7 @@ describe("WebSocket Server", () => {
             });
             expect(res2).to.eql({
               jsonrpc: "2.0",
-              result: 3,
+              result: "Hello Isaac",
               id: 1
             });
             done();


### PR DESCRIPTION
- Use protocol classes to handle multiple connections to server

Protocol classes separate the message buffer on a per-client basis. This allows multiple clients to connect to a server instance without the potential of clashing messages.