### PR TITLE
Bugfix/#54/timeout errors rejected as string

### DIFF
--- a/src/client-ws/ws.js
+++ b/src/client-ws/ws.js
@@ -167,13 +167,15 @@ class WSClient extends EventTarget {
         }
         setTimeout(() => {
           try {
-            const error = formatError({
-              jsonrpc: this.options.version,
-              delimiter: this.options.delimiter,
-              id: null,
-              code: ERR_CODES.timeout,
-              message: ERR_MSGS.timeout
-            });
+            const error = JSON.parse(
+              formatError({
+                jsonrpc: this.options.version,
+                delimiter: this.options.delimiter,
+                id: null,
+                code: ERR_CODES.timeout,
+                message: ERR_MSGS.timeout
+              })
+            );
             this.pendingCalls[requestId].reject(error);
             delete this.pendingCalls[requestId];
           } catch (e) {
@@ -238,13 +240,15 @@ class WSClient extends EventTarget {
       }
       setTimeout(() => {
         try {
-          const error = formatError({
-            jsonrpc: this.options.version,
-            delimiter: this.options.delimiter,
-            id: null,
-            code: ERR_CODES.timeout,
-            message: ERR_MSGS.timeout
-          });
+          const error = JSON.parse(
+            formatError({
+              jsonrpc: this.options.version,
+              delimiter: this.options.delimiter,
+              id: null,
+              code: ERR_CODES.timeout,
+              message: ERR_MSGS.timeout
+            })
+          );
           this.pendingBatches[String(batchIds)].reject(error);
           delete this.pendingBatches[String(batchIds)];
         } catch (e) {

--- a/src/client/http.js
+++ b/src/client/http.js
@@ -79,13 +79,15 @@ class HTTPClient extends Client {
 
         setTimeout(() => {
           try {
-            const error = formatError({
-              jsonrpc: this.options.version,
-              delimiter: this.options.delimiter,
-              id: null,
-              code: ERR_CODES.timeout,
-              message: ERR_MSGS.timeout
-            });
+            const error = JSON.parse(
+              formatError({
+                jsonrpc: this.options.version,
+                delimiter: this.options.delimiter,
+                id: null,
+                code: ERR_CODES.timeout,
+                message: ERR_MSGS.timeout
+              })
+            );
             this.pendingCalls[requestId].reject(error);
             delete this.pendingCalls[requestId];
           } catch (e) {
@@ -175,13 +177,15 @@ class HTTPClient extends Client {
       }
       setTimeout(() => {
         try {
-          const error = formatError({
-            jsonrpc: this.options.version,
-            delimiter: this.options.delimiter,
-            id: null,
-            code: ERR_CODES.timeout,
-            message: ERR_MSGS.timeout
-          });
+          const error = JSON.parse(
+            formatError({
+              jsonrpc: this.options.version,
+              delimiter: this.options.delimiter,
+              id: null,
+              code: ERR_CODES.timeout,
+              message: ERR_MSGS.timeout
+            })
+          );
           this.pendingBatches[String(batchIds)].reject(error);
           delete this.pendingBatches[String(batchIds)];
         } catch (e) {

--- a/src/client/tcp.js
+++ b/src/client/tcp.js
@@ -71,13 +71,15 @@ class TCPClient extends Client {
         }
         setTimeout(() => {
           try {
-            const error = formatError({
-              jsonrpc: this.options.version,
-              delimiter: this.options.delimiter,
-              id: null,
-              code: ERR_CODES.timeout,
-              message: ERR_MSGS.timeout
-            });
+            const error = JSON.parse(
+              formatError({
+                jsonrpc: this.options.version,
+                delimiter: this.options.delimiter,
+                id: null,
+                code: ERR_CODES.timeout,
+                message: ERR_MSGS.timeout
+              })
+            );
             this.pendingCalls[requestId].reject(error);
             delete this.pendingCalls[requestId];
           } catch (e) {
@@ -140,13 +142,15 @@ class TCPClient extends Client {
       }
       setTimeout(() => {
         try {
-          const error = formatError({
-            jsonrpc: this.options.version,
-            delimiter: this.options.delimiter,
-            id: null,
-            code: ERR_CODES.timeout,
-            message: ERR_MSGS.timeout
-          });
+          const error = JSON.parse(
+            formatError({
+              jsonrpc: this.options.version,
+              delimiter: this.options.delimiter,
+              id: null,
+              code: ERR_CODES.timeout,
+              message: ERR_MSGS.timeout
+            })
+          );
           this.pendingBatches[String(batchIds)].reject(error);
           delete this.pendingBatches[String(batchIds)];
         } catch (e) {

--- a/src/client/ws.js
+++ b/src/client/ws.js
@@ -96,13 +96,15 @@ class WSClient extends Client {
         }
         setTimeout(() => {
           try {
-            const error = formatError({
-              jsonrpc: this.options.version,
-              delimiter: this.options.delimiter,
-              id: null,
-              code: ERR_CODES.timeout,
-              message: ERR_MSGS.timeout
-            });
+            const error = JSON.parse(
+              formatError({
+                jsonrpc: this.options.version,
+                delimiter: this.options.delimiter,
+                id: null,
+                code: ERR_CODES.timeout,
+                message: ERR_MSGS.timeout
+              })
+            );
             this.pendingCalls[requestId].reject(error);
             delete this.pendingCalls[requestId];
           } catch (e) {
@@ -166,13 +168,15 @@ class WSClient extends Client {
       }
       setTimeout(() => {
         try {
-          const error = formatError({
-            jsonrpc: this.options.version,
-            delimiter: this.options.delimiter,
-            id: null,
-            code: ERR_CODES.timeout,
-            message: ERR_MSGS.timeout
-          });
+          const error = JSON.parse(
+            formatError({
+              jsonrpc: this.options.version,
+              delimiter: this.options.delimiter,
+              id: null,
+              code: ERR_CODES.timeout,
+              message: ERR_MSGS.timeout
+            })
+          );
           this.pendingBatches[String(batchIds)].reject(error);
           delete this.pendingBatches[String(batchIds)];
         } catch (e) {

--- a/tests/issues/#51-no-params.test.js
+++ b/tests/issues/#51-no-params.test.js
@@ -1,13 +1,13 @@
 const { expect } = require("chai");
 const Jaysonic = require("../../src");
 
-const tcpserver = new Jaysonic.server.tcp({ port: 9999 });
+const tcpserver = new Jaysonic.server.tcp({ port: 6666 });
 const httpserver = new Jaysonic.server.http({ port: 9998 });
-const wss = new Jaysonic.server.ws();
+const wss = new Jaysonic.server.ws({ port: 6667 });
 
-const tcpclient = new Jaysonic.client.tcp({ port: 9999 });
+const tcpclient = new Jaysonic.client.tcp({ port: 6666 });
 const httpclient = new Jaysonic.client.http({ port: 9998 });
-const wsclient = new Jaysonic.client.ws();
+const wsclient = new Jaysonic.client.ws({ url: "ws://127.0.0.1:6667" });
 
 const noParams = () => "success";
 

--- a/tests/issues/#54-request-timeout.test.js
+++ b/tests/issues/#54-request-timeout.test.js
@@ -1,0 +1,79 @@
+const { expect } = require("chai");
+const Jaysonic = require("../../src");
+
+const tcpserver = new Jaysonic.server.tcp({ port: 9997 });
+const httpserver = new Jaysonic.server.http({ port: 9996 });
+const wss = new Jaysonic.server.ws({ port: 6665 });
+
+const tcpclient = new Jaysonic.client.tcp({ port: 9997, timeout: 0 });
+const httpclient = new Jaysonic.client.http({ port: 9996, timeout: 0 });
+const wsclient = new Jaysonic.client.ws({
+  url: "ws://127.0.0.1:6665",
+  timeout: 0
+});
+
+const timeout = () => new Promise((resolve) => {
+  setTimeout(() => resolve("timeout"), 10);
+});
+
+tcpserver.method("timeout", timeout);
+httpserver.method("timeout", timeout);
+wss.method("timeout", timeout);
+
+describe("#54 Request timeout", () => {
+  describe("tcp", () => {
+    it("should return object for request timeout", (done) => {
+      tcpserver.listen().then(() => {
+        tcpclient.connect().then(() => {
+          tcpclient
+            .request()
+            .send("timeout")
+            .catch((error) => {
+              expect(error).to.be.eql({
+                jsonrpc: "2.0",
+                error: { code: -32000, message: "Request Timeout" },
+                id: null
+              });
+              done();
+            });
+        });
+      });
+    });
+  });
+  describe("ws", () => {
+    it("should return object for request timeout", (done) => {
+      wss.listen().then(() => {
+        wsclient.connect().then(() => {
+          wsclient
+            .request()
+            .send("timeout")
+            .catch((error) => {
+              expect(error).to.be.eql({
+                jsonrpc: "2.0",
+                error: { code: -32000, message: "Request Timeout" },
+                id: null
+              });
+              done();
+            });
+        });
+      });
+    });
+  });
+  describe("http", () => {
+    it("should return object for request timeout", (done) => {
+      httpserver.listen().then(() => {
+        httpclient
+          .request()
+          .send("timeout")
+          .catch((error) => {
+            expect(error).to.be.eql({
+              jsonrpc: "2.0",
+              error: { code: -32000, message: "Request Timeout" },
+              id: null
+            });
+            done();
+          });
+      });
+    });
+  });
+});

--- a/tests/issues/#54-request-timeout.test.js
+++ b/tests/issues/#54-request-timeout.test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
 const Jaysonic = require("../../src");
+const JaysonicWebClient = require("../../src/client-ws");
 
 const tcpserver = new Jaysonic.server.tcp({ port: 9997 });
 const httpserver = new Jaysonic.server.http({ port: 9996 });
@@ -8,6 +9,10 @@ const wss = new Jaysonic.server.ws({ port: 6665 });
 const tcpclient = new Jaysonic.client.tcp({ port: 9997, timeout: 0 });
 const httpclient = new Jaysonic.client.http({ port: 9996, timeout: 0 });
 const wsclient = new Jaysonic.client.ws({
+  url: "ws://127.0.0.1:6665",
+  timeout: 0
+});
+const wsweb = new JaysonicWebClient.wsclient({
   url: "ws://127.0.0.1:6665",
   timeout: 0
 });
@@ -56,6 +61,23 @@ describe("#54 Request timeout", () => {
               done();
             });
         });
+      });
+    });
+  });
+  describe("ws web", () => {
+    it("should return object for request timeout", (done) => {
+      wsweb.connect().then(() => {
+        wsweb
+          .request()
+          .send("timeout")
+          .catch((error) => {
+            expect(error).to.be.eql({
+              jsonrpc: "2.0",
+              error: { code: -32000, message: "Request Timeout" },
+              id: null
+            });
+            done();
+          });
       });
     });
   });


### PR DESCRIPTION
Return timeout errors as an object.
Fix issues tests, including the no-params tests.