### PR TITLE
Bugfix/#58/batch response listeners not removed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     "new-cap": "off",
     "class-methods-use-this": "off",
     "comma-dangle": "off",
+    "no-await-in-loop": "off",
     quotes: ["error", "double"],
     "consistent-return": "off",
     "no-restricted-syntax": [

--- a/src/client-ws/ws.js
+++ b/src/client-ws/ws.js
@@ -265,8 +265,6 @@ class WSClient extends EventTarget {
   }
 
   gotBatchResponse({ detail }) {
-    // remove listener
-    this.removeEventListener("batchResponse", this.gotBatchResponse);
     const batch = detail;
     const batchResponseIds = [];
     batch.forEach((message) => {

--- a/src/client/http.js
+++ b/src/client/http.js
@@ -196,39 +196,34 @@ class HTTPClient extends Client {
           }
         }
       }, this.options.timeout);
-      this.on("batchResponse", (batch) => {
-        const batchResponseIds = [];
+      this.on("batchResponse", this.gotBatchResponse);
+    });
+  }
+
+  gotBatchResponse(batch) {
+    this.removeListener("batchResponse", this.gotBatchResponse);
+    const batchResponseIds = [];
+    batch.forEach((message) => {
+      if (message.id) {
+        batchResponseIds.push(message.id);
+      }
+    });
+    if (batchResponseIds.length === 0) {
+      // do nothing since this is basically an invalid response
+    }
+    for (const ids of Object.keys(this.pendingBatches)) {
+      const arrays = [JSON.parse(`[${ids}]`), batchResponseIds];
+      const difference = arrays.reduce((a, b) => a.filter(c => !b.includes(c)));
+      if (difference.length === 0) {
+        const response = {
+          body: batch,
+          ...this.writer
+        };
         batch.forEach((message) => {
-          if (message.id) {
-            batchResponseIds.push(message.id);
-          }
-        });
-        if (batchResponseIds.length === 0) {
-          resolve([]);
-        }
-        for (const ids of Object.keys(this.pendingBatches)) {
-          const arrays = [JSON.parse(`[${ids}]`), batchResponseIds];
-          const difference = arrays.reduce((a, b) => a.filter(c => !b.includes(c)));
-          if (difference.length === 0) {
-            const response = {
-              body: batch,
-              ...this.writer
-            };
-            batch.forEach((message) => {
-              if (message.error) {
-                // reject the whole message if there are any errors
-                try {
-                  this.pendingBatches[ids].reject(response);
-                  delete this.pendingBatches[ids];
-                } catch (e) {
-                  if (e instanceof TypeError) {
-                    // no outstanding calls
-                  }
-                }
-              }
-            });
+          if (message.error) {
+            // reject the whole message if there are any errors
             try {
-              this.pendingBatches[ids].resolve(response);
+              this.pendingBatches[ids].reject(response);
               delete this.pendingBatches[ids];
             } catch (e) {
               if (e instanceof TypeError) {
@@ -236,9 +231,17 @@ class HTTPClient extends Client {
               }
             }
           }
+        });
+        try {
+          this.pendingBatches[ids].resolve(response);
+          delete this.pendingBatches[ids];
+        } catch (e) {
+          if (e instanceof TypeError) {
+            // no outstanding calls
+          }
         }
-      });
-    });
+      }
+    }
   }
 }
 

--- a/src/client/http.js
+++ b/src/client/http.js
@@ -71,6 +71,9 @@ class HTTPClient extends Client {
         try {
           this.client.write(request, this.options.encoding);
           this.client.end();
+          this.client.on("close", () => {
+            this.emit("serverDisconnected");
+          });
           this.client.on("error", (error) => {
             reject(error);
           });
@@ -172,6 +175,9 @@ class HTTPClient extends Client {
         this.client.end();
         this.client.on("error", (error) => {
           reject(error);
+        });
+        this.client.on("close", () => {
+          this.emit("serverDisconnected");
         });
       } catch (e) {
         reject(e);

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -98,7 +98,7 @@ class Client extends EventEmitter {
       if (e instanceof TypeError) {
         // probably a parse error, which might not have an id
         process.stdout.write(
-          `Message has no outstanding calls: ${JSON.stringify(e)}\n`
+          `Message has no outstanding calls: ${JSON.stringify(e.message)}\n`
         );
       }
     }
@@ -194,11 +194,15 @@ class Client extends EventEmitter {
         this.handleData(data);
       }
     });
-    this.client.on("close", () => {
-      this.attached = false;
-      this.client.removeAllListeners();
-      this.emit("serverDisconnected");
-    });
+    // http client handles this when a request is sent out
+    // prevents max listeners warning
+    if (!(this.writer instanceof http.IncomingMessage)) {
+      this.client.on("close", () => {
+        this.attached = false;
+        this.client.removeAllListeners();
+        this.emit("serverDisconnected");
+      });
+    }
   }
 
   handleData(data) {

--- a/src/client/ws.js
+++ b/src/client/ws.js
@@ -187,35 +187,31 @@ class WSClient extends Client {
           }
         }
       }, this.options.timeout);
-      this.on("batchResponse", (batch) => {
-        const batchResponseIds = [];
+      this.on("batchResponse", this.gotBatchResponse);
+    });
+  }
+
+  gotBatchResponse(batch) {
+    // remove listener
+    this.removeListener("batchResponse", this.gotBatchResponse);
+    const batchResponseIds = [];
+    batch.forEach((message) => {
+      if (message.id) {
+        batchResponseIds.push(message.id);
+      }
+    });
+    if (batchResponseIds.length === 0) {
+      // dont do anything here since its basically an invalid response
+    }
+    for (const ids of Object.keys(this.pendingBatches)) {
+      const arrays = [JSON.parse(`[${ids}]`), batchResponseIds];
+      const difference = arrays.reduce((a, b) => a.filter(c => !b.includes(c)));
+      if (difference.length === 0) {
         batch.forEach((message) => {
-          if (message.id) {
-            batchResponseIds.push(message.id);
-          }
-        });
-        if (batchResponseIds.length === 0) {
-          resolve([]);
-        }
-        for (const ids of Object.keys(this.pendingBatches)) {
-          const arrays = [JSON.parse(`[${ids}]`), batchResponseIds];
-          const difference = arrays.reduce((a, b) => a.filter(c => !b.includes(c)));
-          if (difference.length === 0) {
-            batch.forEach((message) => {
-              if (message.error) {
-                // reject the whole message if there are any errors
-                try {
-                  this.pendingBatches[ids].reject(batch);
-                  delete this.pendingBatches[ids];
-                } catch (e) {
-                  if (e instanceof TypeError) {
-                    // no outstanding calls
-                  }
-                }
-              }
-            });
+          if (message.error) {
+            // reject the whole message if there are any errors
             try {
-              this.pendingBatches[ids].resolve(batch);
+              this.pendingBatches[ids].reject(batch);
               delete this.pendingBatches[ids];
             } catch (e) {
               if (e instanceof TypeError) {
@@ -223,9 +219,17 @@ class WSClient extends Client {
               }
             }
           }
+        });
+        try {
+          this.pendingBatches[ids].resolve(batch);
+          delete this.pendingBatches[ids];
+        } catch (e) {
+          if (e instanceof TypeError) {
+            // no outstanding calls
+          }
         }
-      });
-    });
+      }
+    }
   }
 
   /**

--- a/tests/client/http-client.test.js
+++ b/tests/client/http-client.test.js
@@ -23,14 +23,15 @@ describe("HTTP Client", () => {
     it("should receive error trying to write while disconnected", (done) => {
       const badClient = new Jaysonic.client.http({
         host: "127.0.0.1",
-        port: 8101,
-        retries: 0
+        port: 8102,
+        retries: 0,
+        timeout: 0.05
       });
       badClient
         .request()
         .send("add", [1, 2])
         .catch((error) => {
-          expect(error).to.be.instanceOf(Error);
+          expect(error).to.be.instanceOf(Object);
           done();
         });
     });

--- a/tests/client/tcp-client.test.js
+++ b/tests/client/tcp-client.test.js
@@ -308,14 +308,14 @@ describe("TCP Client", () => {
     it("should unsubscribe from a notificiation", (done) => {
       const callback = () => {};
       client.subscribe("newNotification", callback);
-      expect(client.eventNames()).to.have.lengthOf(3);
-      client.unsubscribe("newNotification", callback);
       expect(client.eventNames()).to.have.lengthOf(2);
+      client.unsubscribe("newNotification", callback);
+      expect(client.eventNames()).to.have.lengthOf(1);
       done();
     });
     it("should unsubscribe from all 'notification' events", (done) => {
       client.unsubscribeAll("notification");
-      expect(client.eventNames()).to.have.lengthOf(1);
+      expect(client.eventNames()).to.have.lengthOf(0);
       done();
     });
     it("should recieve notifications if they're in a batch", (done) => {

--- a/tests/client/tcp-client.test.js
+++ b/tests/client/tcp-client.test.js
@@ -54,7 +54,7 @@ describe("TCP Client", () => {
         expect(error.code).to.equal("ECONNREFUSED");
         done();
       });
-    });
+    }).timeout(5000);
     it("should be unable to connect multiple times", (done) => {
       const conn = client.connect();
       conn.catch((error) => {
@@ -66,13 +66,14 @@ describe("TCP Client", () => {
       const badClient = new Jaysonic.client.tcp({
         host: "127.0.0.1",
         port: 8101,
-        retries: 0
+        retries: 0,
+        timeout: 0.5
       });
       badClient
         .request()
         .send("add", [1, 2])
         .catch((error) => {
-          expect(error).to.be.instanceOf(Error);
+          expect(error).to.be.instanceOf(TypeError);
           done();
         });
     });

--- a/tests/client/ws-client-node.test.js
+++ b/tests/client/ws-client-node.test.js
@@ -232,14 +232,14 @@ describe("WebSocket Node Client", () => {
     it("should unsubscribe from a notificiation", (done) => {
       const callback = () => {};
       ws.subscribe("newNotification", callback);
-      expect(ws.eventNames()).to.have.lengthOf(3);
-      ws.unsubscribe("newNotification", callback);
       expect(ws.eventNames()).to.have.lengthOf(2);
+      ws.unsubscribe("newNotification", callback);
+      expect(ws.eventNames()).to.have.lengthOf(1);
       done();
     });
     it("should unsubscribe from all 'notification' events", (done) => {
       ws.unsubscribeAll("notification");
-      expect(ws.eventNames()).to.have.lengthOf(1);
+      expect(ws.eventNames()).to.have.lengthOf(0);
       done();
     });
     it("should recieve notifications if they're in a batch", (done) => {

--- a/tests/client/ws-client.test.js
+++ b/tests/client/ws-client.test.js
@@ -158,33 +158,37 @@ describe("WebSocket Client", () => {
         ws.request().message("nonexistent", [1, 2]),
         ws.request().message("add", [3, 4])
       ]);
-      request.then((res1) => {
-        expect(res1).to.eql({ jsonrpc: "2.0", result: 3, id: 8 });
+      try {
+        request.then((res1) => {
+          expect(res1).to.eql({ jsonrpc: "2.0", result: 3, id: 8 });
+        });
         request2.then((res2) => {
           expect(res2).to.eql({
             jsonrpc: "2.0",
             result: "Hello Isaac",
             id: 9
           });
-          request3.then((res3) => {
-            expect(res3).to.eql([
-              { result: 3, jsonrpc: "2.0", id: 10 },
-              { result: 7, jsonrpc: "2.0", id: 11 }
-            ]);
-            request4.catch((res4) => {
-              expect(res4).to.eql([
-                {
-                  jsonrpc: "2.0",
-                  error: { code: -32601, message: "Method not found" },
-                  id: 12
-                },
-                { result: 7, jsonrpc: "2.0", id: 13 }
-              ]);
-              done();
-            });
-          });
         });
-      });
+        request3.then((res3) => {
+          expect(res3).to.eql([
+            { result: 3, jsonrpc: "2.0", id: 10 },
+            { result: 7, jsonrpc: "2.0", id: 11 }
+          ]);
+        });
+        request4.catch((res4) => {
+          expect(res4).to.eql([
+            {
+              jsonrpc: "2.0",
+              error: { code: -32601, message: "Method not found" },
+              id: 12
+            },
+            { result: 7, jsonrpc: "2.0", id: 13 }
+          ]);
+        });
+        done();
+      } catch (e) {
+        done(e);
+      }
     });
   });
   describe("request errors", () => {

--- a/tests/issues/#54-request-timeout.test.js
+++ b/tests/issues/#54-request-timeout.test.js
@@ -6,24 +6,30 @@ const tcpserver = new Jaysonic.server.tcp({ port: 9997 });
 const httpserver = new Jaysonic.server.http({ port: 9996 });
 const wss = new Jaysonic.server.ws({ port: 6665 });
 
-const tcpclient = new Jaysonic.client.tcp({ port: 9997, timeout: 0 });
-const httpclient = new Jaysonic.client.http({ port: 9996, timeout: 0 });
+const tcpclient = new Jaysonic.client.tcp({
+  port: 9997,
+  timeout: 0,
+  delimiter: "\r\n"
+});
+const httpclient = new Jaysonic.client.http({
+  port: 9996,
+  timeout: 0,
+  delimiter: "\r\n"
+});
 const wsclient = new Jaysonic.client.ws({
   url: "ws://127.0.0.1:6665",
-  timeout: 0
+  timeout: 0,
+  delimiter: "\r\n"
 });
 const wsweb = new JaysonicWebClient.wsclient({
   url: "ws://127.0.0.1:6665",
-  timeout: 0
+  timeout: 0,
+  delimiter: "\r\n"
 });
 
-const timeout = () => new Promise((resolve) => {
-  setTimeout(() => resolve("timeout"), 10);
-});
-
-tcpserver.method("timeout", timeout);
-httpserver.method("timeout", timeout);
-wss.method("timeout", timeout);
+tcpserver.method("timeout", 0);
+httpserver.method("timeout", 0);
+wss.method("timeout", 0);
 
 describe("#54 Request timeout", () => {
   describe("tcp", () => {

--- a/tests/issues/#58-batchresponse-memory-leak.test.js
+++ b/tests/issues/#58-batchresponse-memory-leak.test.js
@@ -1,0 +1,62 @@
+const { expect } = require("chai");
+const intercept = require("intercept-stdout");
+const Jaysonic = require("../../src");
+
+describe("#58 batchResponse causing memory leak", () => {
+  describe("tcp", () => {
+    it("shouldnt cause a 'MaxListenersExceededWarning'", async () => {
+      let capturedText = "";
+      const unhook = intercept((text) => {
+        capturedText += text;
+      });
+      const server = new Jaysonic.server.tcp({ port: 8888 });
+      await server.listen();
+      server.method("f", () => 0);
+      const client = new Jaysonic.client.tcp({ port: 8888 });
+      await client.connect();
+      for (let i = 0; i <= 11; i += 1) {
+        await client.batch([client.request().message("f")]);
+      }
+      unhook();
+      expect(capturedText).to.equal("");
+    });
+  });
+  describe("ws", () => {
+    it("shouldnt cause a 'MaxListenersExceededWarning'", async () => {
+      let capturedText = "";
+      const unhook = intercept((text) => {
+        capturedText += text;
+      });
+      const server = new Jaysonic.server.ws({ port: 8200 });
+      await server.listen();
+      server.method("f", () => 0);
+      const client = new Jaysonic.client.ws({ url: "ws://127.0.0.1:8200" });
+      await client.connect();
+      for (let i = 0; i <= 11; i += 1) {
+        await client.batch([client.request().message("f")]);
+      }
+      unhook();
+      expect(capturedText).to.equal("");
+    });
+  });
+  describe("http", () => {
+    it("shouldnt cause a 'MaxListenersExceededWarning'", async () => {
+      let capturedText = "";
+      const unhook = intercept((text) => {
+        capturedText += text;
+      });
+      const server = new Jaysonic.server.http({ port: 8300 });
+      await server.listen();
+      server.method("f", () => 0);
+
+      const client = new Jaysonic.client.http({
+        port: 8300
+      });
+      for (let i = 0; i <= 11; i += 1) {
+        await client.batch([client.request().message("f")]);
+      }
+      unhook();
+      expect(capturedText).to.equal("");
+    });
+  });
+});


### PR DESCRIPTION
Remove `batchResponse` listeners when a response is received or the request times out.
Move .on("close") handler for HTTP client to sub class.
Add tests for tcp, http and node ws client.
Fix a bunch of broken tests.
Add new .eslintrc rule.