### PR TITLE
Clear request timeouts on response or after timeout is called.

### DIFF
--- a/src/client-ws/ws.js
+++ b/src/client-ws/ws.js
@@ -158,37 +158,39 @@ class WSClient extends EventTarget {
         }
         return request;
       },
-      send: (method, params) => new Promise((resolve, reject) => {
-        const requestId = this.message_id;
-        this.pendingCalls[requestId] = { resolve, reject };
-        try {
-          this.client.send(this.request().message(method, params));
-        } catch (e) {
-          reject(e);
-        }
-        this.timeouts[requestId] = setTimeout(() => {
+      send: (method, params) =>
+        new Promise((resolve, reject) => {
+          const requestId = this.message_id;
+          this.pendingCalls[requestId] = { resolve, reject };
           try {
-            const error = JSON.parse(
-              formatError({
-                jsonrpc: this.options.version,
-                delimiter: this.options.delimiter,
-                id: null,
-                code: ERR_CODES.timeout,
-                message: ERR_MSGS.timeout
-              })
-            );
-            this.pendingCalls[requestId].reject(error);
-            delete this.pendingCalls[requestId];
+            this.client.send(this.request().message(method, params));
           } catch (e) {
-            if (e instanceof TypeError) {
-              // probably a parse error, which might not have an id
-              console.log(
-                `Message has no outstanding calls: ${JSON.stringify(e)}`
-              );
-            }
+            reject(e);
           }
-        }, this.options.timeout);
-      }),
+          this.timeouts[requestId] = setTimeout(() => {
+            this.cleanUp(requestId);
+            try {
+              const error = JSON.parse(
+                formatError({
+                  jsonrpc: this.options.version,
+                  delimiter: this.options.delimiter,
+                  id: null,
+                  code: ERR_CODES.timeout,
+                  message: ERR_MSGS.timeout
+                })
+              );
+              this.pendingCalls[requestId].reject(error);
+              delete this.pendingCalls[requestId];
+            } catch (e) {
+              if (e instanceof TypeError) {
+                // probably a parse error, which might not have an id
+                console.log(
+                  `Message has no outstanding calls: ${JSON.stringify(e)}`
+                );
+              }
+            }
+          }, this.options.timeout);
+        }),
       notify: (method, params) => {
         const request = formatRequest({
           method,
@@ -240,6 +242,7 @@ class WSClient extends EventTarget {
         reject(e.message);
       }
       this.timeouts[String(batchIds)] = setTimeout(() => {
+        this.cleanUp(String(batchIds));
         try {
           const error = JSON.parse(
             formatError({
@@ -278,7 +281,9 @@ class WSClient extends EventTarget {
     }
     for (const ids of Object.keys(this.pendingBatches)) {
       const arrays = [JSON.parse(`[${ids}]`), batchResponseIds];
-      const difference = arrays.reduce((a, b) => a.filter(c => !b.includes(c)));
+      const difference = arrays.reduce((a, b) =>
+        a.filter((c) => !b.includes(c))
+      );
       if (difference.length === 0) {
         this.cleanUp(ids);
         batch.forEach((message) => {
@@ -372,7 +377,7 @@ class WSClient extends EventTarget {
    */
   subscribe(method, cb) {
     if (method === "batchResponse") {
-      throw new Error("\"batchResponse\" is a reserved event name");
+      throw new Error('"batchResponse" is a reserved event name');
     }
     if (!this.eventListenerList) this.eventListenerList = {};
     if (!this.eventListenerList[method]) this.eventListenerList[method] = [];
@@ -391,7 +396,7 @@ class WSClient extends EventTarget {
    */
   unsubscribe(method, cb) {
     if (method === "batchResponse") {
-      throw new Error("\"batchResponse\" is a reserved event name");
+      throw new Error('"batchResponse" is a reserved event name');
     }
     // remove listener
     this.removeEventListener(method, cb);
@@ -407,12 +412,13 @@ class WSClient extends EventTarget {
       }
     }
     // if no more events of the removed event method are left,remove the group
-    if (this.eventListenerList[method].length === 0) delete this.eventListenerList[method];
+    if (this.eventListenerList[method].length === 0)
+      delete this.eventListenerList[method];
   }
 
   unsubscribeAll(method) {
     if (method === "batchResponse") {
-      throw new Error("\"batchResponse\" is a reserved event name");
+      throw new Error('"batchResponse" is a reserved event name');
     }
     if (!this.eventListenerList) this.eventListenerList = {};
     if (!this.eventListenerList[method]) this.eventListenerList[method] = [];

--- a/src/client-ws/ws.js
+++ b/src/client-ws/ws.js
@@ -280,7 +280,7 @@ class WSClient extends EventTarget {
       const arrays = [JSON.parse(`[${ids}]`), batchResponseIds];
       const difference = arrays.reduce((a, b) => a.filter(c => !b.includes(c)));
       if (difference.length === 0) {
-        clearTimeout(ids);
+        this.cleanUp(ids);
         batch.forEach((message) => {
           if (message.error) {
             // reject the whole message if there are any errors
@@ -311,7 +311,7 @@ class WSClient extends EventTarget {
       const response = this.responseQueue[id];
       this.pendingCalls[id].resolve(response);
       delete this.responseQueue[id];
-      clearTimeout(id);
+      this.cleanUp(id);
     } catch (e) {
       if (e instanceof TypeError) {
         // probably a parse error, which might not have an id
@@ -349,7 +349,7 @@ class WSClient extends EventTarget {
     }
     try {
       this.pendingCalls[response.id].reject(response);
-      clearTimeout(response.id);
+      this.cleanUp(response.id);
     } catch (e) {
       if (e instanceof TypeError) {
         // probably a parse error, which might not have an id
@@ -358,6 +358,12 @@ class WSClient extends EventTarget {
         );
       }
     }
+  }
+
+  cleanUp(ids) {
+    // clear pending timeouts for these request ids
+    clearTimeout(this.timeouts[ids]);
+    delete this.timeouts[ids];
   }
 
   /**

--- a/src/client/http.js
+++ b/src/client/http.js
@@ -81,7 +81,8 @@ class HTTPClient extends Client {
           reject(e);
         }
 
-        setTimeout(() => {
+        this.timeouts[requestId] = setTimeout(() => {
+          this.cleanUp(requestId);
           try {
             const error = JSON.parse(
               formatError({
@@ -182,9 +183,9 @@ class HTTPClient extends Client {
       } catch (e) {
         reject(e);
       }
-      setTimeout(() => {
+      this.timeouts[String(batchIds)] = setTimeout(() => {
         // remove listener
-        this.removeListener("batchResponse", this.listeners[String(batchIds)]);
+        this.cleanUp(String(batchIds));
         try {
           const error = JSON.parse(
             formatError({
@@ -225,8 +226,7 @@ class HTTPClient extends Client {
       const arrays = [JSON.parse(`[${ids}]`), batchResponseIds];
       const difference = arrays.reduce((a, b) => a.filter(c => !b.includes(c)));
       if (difference.length === 0) {
-        // remove listener
-        this.removeListener("batchResponse", this.listeners[ids]);
+        this.cleanUp(ids);
         const response = {
           body: batch,
           ...this.writer

--- a/src/client/ws.js
+++ b/src/client/ws.js
@@ -24,7 +24,6 @@ class WSClient extends Client {
     this.pendingCalls = {};
     this.pendingBatches = {};
     this.attached = false;
-    this.listeners = {};
 
     this.responseQueue = {};
     this.options = {
@@ -95,7 +94,8 @@ class WSClient extends Client {
         } catch (e) {
           reject(e);
         }
-        setTimeout(() => {
+        this.timeouts[requestId] = setTimeout(() => {
+          this.cleanUp(requestId);
           try {
             const error = JSON.parse(
               formatError({
@@ -167,9 +167,9 @@ class WSClient extends Client {
         // this.client is probably undefined
         reject(e.message);
       }
-      setTimeout(() => {
+      this.timeouts[String(batchIds)] = setTimeout(() => {
         // remove listener
-        this.removeListener("batchResponse", this.listeners[String(batchIds)]);
+        this.cleanUp(String(batchIds));
         try {
           const error = JSON.parse(
             formatError({
@@ -210,8 +210,7 @@ class WSClient extends Client {
       const arrays = [JSON.parse(`[${ids}]`), batchResponseIds];
       const difference = arrays.reduce((a, b) => a.filter(c => !b.includes(c)));
       if (difference.length === 0) {
-        // remove listener
-        this.removeListener("batchResponse", this.listeners[ids]);
+        this.cleanUp(ids);
         batch.forEach((message) => {
           if (message.error) {
             // reject the whole message if there are any errors

--- a/tests/issues/#58-batchresponse-memory-leak.test.js
+++ b/tests/issues/#58-batchresponse-memory-leak.test.js
@@ -19,6 +19,7 @@ describe("#58 batchResponse causing memory leak", () => {
       }
       unhook();
       expect(capturedText).to.equal("");
+      expect(Object.keys(client.listeners).length).to.be.equal(0);
     });
   });
   describe("ws", () => {
@@ -37,6 +38,7 @@ describe("#58 batchResponse causing memory leak", () => {
       }
       unhook();
       expect(capturedText).to.equal("");
+      expect(Object.keys(client.listeners).length).to.be.equal(0);
     });
   });
   describe("http", () => {
@@ -57,6 +59,7 @@ describe("#58 batchResponse causing memory leak", () => {
       }
       unhook();
       expect(capturedText).to.equal("");
+      expect(Object.keys(client.listeners).length).to.be.equal(0);
     });
   });
 });

--- a/tests/issues/#59-setTimeout-not-cancelled.test.js
+++ b/tests/issues/#59-setTimeout-not-cancelled.test.js
@@ -1,0 +1,50 @@
+const { expect } = require("chai");
+const Jaysonic = require("../../src");
+
+describe("#59 setTimeout not cancelled", () => {
+  describe("tcp", () => {
+    it("should have no outstanding timeouts'", async () => {
+      const server = new Jaysonic.server.tcp({ port: 8603 });
+      await server.listen();
+      server.method("f", () => 0);
+
+      const client = new Jaysonic.client.tcp({ timeout: 10, port: 8603 });
+      await client.connect();
+      for (let i = 0; i <= 11; i += 1) {
+        await client.request().send("f");
+      }
+      await client.end();
+      await server.close();
+      expect(Object.keys(client.timeouts).length).to.be.equal(0);
+    });
+  });
+  describe("ws", () => {
+    it("should have no outstanding timeouts", async () => {
+      const server = new Jaysonic.server.ws({ port: 8601 });
+      await server.listen();
+      server.method("f", () => 0);
+
+      const client = new Jaysonic.client.ws({
+        url: "ws://127.0.0.1:8601",
+        timeout: 10
+      });
+      await client.connect();
+      for (let i = 0; i <= 11; i += 1) {
+        await client.request().send("f");
+      }
+      expect(Object.keys(client.timeouts).length).to.be.equal(0);
+    });
+  });
+  describe("http", () => {
+    it("should have no outstanding timeouts", async () => {
+      const server = new Jaysonic.server.http({ port: 8602 });
+      await server.listen();
+      server.method("f", () => 0);
+      const client = new Jaysonic.client.http({ port: 8602, timeout: 10 });
+      for (let i = 0; i <= 11; i += 1) {
+        await client.request().send("f");
+      }
+      expect(Object.keys(client.timeouts).length).to.be.equal(0);
+    });
+  });
+});

--- a/tests/issues/#59-setTimeout-not-cancelled.test.js
+++ b/tests/issues/#59-setTimeout-not-cancelled.test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
 const Jaysonic = require("../../src");
+const WebSocket = require("../../src/client-ws");
 
 describe("#59 setTimeout not cancelled", () => {
   describe("tcp", () => {
@@ -26,6 +27,22 @@ describe("#59 setTimeout not cancelled", () => {
 
       const client = new Jaysonic.client.ws({
         url: "ws://127.0.0.1:8601",
+        timeout: 10
+      });
+      await client.connect();
+      for (let i = 0; i <= 11; i += 1) {
+        await client.request().send("f");
+      }
+      expect(Object.keys(client.timeouts).length).to.be.equal(0);
+    });
+  });
+  describe("ws client", () => {
+    it("should have no outstanding timeouts", async () => {
+      const server = new Jaysonic.server.ws({ port: 8603 });
+      await server.listen();
+      server.method("f", () => 0);
+      const client = new WebSocket.wsclient({
+        url: "ws://127.0.0.1:8603",
         timeout: 10
       });
       await client.connect();


### PR DESCRIPTION
Add cleanUp method to client class for timeouts and batch responses.
Update batchResponse tests to check length of this.listeners.
Refs #59.