### PR TITLE
Bugfix/#94/indefinite retry attempts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
     "consistent-return": "off",
     "max-len": [
       "error",
-      { ignoreComments: true, ignoreTemplateLiterals: true }
+      { ignoreComments: true, ignoreTemplateLiterals: true, code: 90 }
     ],
     "no-console": "off",
     "no-restricted-syntax": [

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The client and server support changing the JSON-RPC version and the delimiter us
 
 #### Client only options
 
-`retries`: The number of retry attempts for the client to connect to the server. Default is `2`. If set to `Infinity` then the client will retry indefinitely.\
+`retries`: The number of retry attempts for the client to connect to the server. Default is `2`. If set to `Infinity` (or some number that Javascript defines as non-finite `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite`) then the client will retry indefinitely.\
 `timeout`: The amount of time before a request times out. Will return a `-32000` error code. The default value is `30` (in seconds). \
 `connectionTimeout`: The amount of time between connection retry attempts to a server. The default value is `5000` (in milliseconds).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Jaysonic - A persistent JSON-RPC client and server](#jaysonic---a-persistent-json-rpc-client-and-server)
   - [List of features](#list-of-features)
   - [Download & Installation](#download--installation)
@@ -19,10 +18,10 @@
       - [Other client and server options](#other-client-and-server-options)
     - [Code Demos](#code-demos)
       - [Initialization](#initialization-1)
-          - [TCP](#tcp)
-          - [HTTP](#http)
-          - [HTTPS](#https)
-          - [Websocket](#websocket)
+        - [TCP](#tcp)
+        - [HTTP](#http)
+        - [HTTPS](#https)
+        - [Websocket](#websocket)
       - [Server side](#server-side)
         - [Instantiation and Listening](#instantiation-and-listening)
         - [Closing the connection](#closing-the-connection)
@@ -206,7 +205,7 @@ The client and server support changing the JSON-RPC version and the delimiter us
 
 #### Client only options
 
-`retries`: The number of retry attempts for the client to connect to the server. Default is `2`. \
+`retries`: The number of retry attempts for the client to connect to the server. Default is `2`. If set to `Infinity` then the client will retry indefinitely.\
 `timeout`: The amount of time before a request times out. Will return a `-32000` error code. The default value is `30` (in seconds). \
 `connectionTimeout`: The amount of time between connection retry attempts to a server. The default value is `5000` (in milliseconds).
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The client and server support changing the JSON-RPC version and the delimiter us
 
 #### Client only options
 
-`retries`: The number of retry attempts for the client to connect to the server. Default is `2`. If set to `Infinity` (or some number that Javascript defines as non-finite `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite`) then the client will retry indefinitely.\
+`retries`: The number of retry attempts for the client to connect to the server. Default is `2`. If set to `null` then the client will retry indefinitely.\
 `timeout`: The amount of time before a request times out. Will return a `-32000` error code. The default value is `30` (in seconds). \
 `connectionTimeout`: The amount of time between connection retry attempts to a server. The default value is `5000` (in milliseconds).
 

--- a/src/client/protocol/base.js
+++ b/src/client/protocol/base.js
@@ -38,6 +38,7 @@ class JsonRpcClientProtocol {
     this.pendingCalls = {};
     this.responseQueue = {};
     this.server = this.factory.server;
+    this._connectionTimeout = undefined;
     this.messageBuffer = new MessageBuffer(this.delimiter);
   }
 
@@ -129,7 +130,7 @@ class JsonRpcClientProtocol {
           `Failed to connect. Address [${this.server.host}:${this.server.port}]. Retrying.`
         );
       }
-      this.connectionTimeout = setTimeout(() => {
+      this._connectionTimeout = setTimeout(() => {
         this._retryConnection(resolve, reject);
       }, this.factory.connectionTimeout);
     } else {
@@ -148,8 +149,8 @@ class JsonRpcClientProtocol {
    * @param {function} cb Called when connection is sucessfully closed
    */
   end(cb) {
+    clearTimeout(this._connectionTimeout);
     this.factory.pcolInstance = undefined;
-    clearTimeout(this.connectionTimeout);
     this.connector.end(cb);
   }
 

--- a/src/client/protocol/base.js
+++ b/src/client/protocol/base.js
@@ -81,12 +81,21 @@ class JsonRpcClientProtocol {
           resolve(this.server);
         });
         this.connector.on("error", (error) => {
-          if (error.code === "ECONNREFUSED" && this.factory.remainingRetries) {
-            this.factory.remainingRetries -= 1;
-            console.error(
-              `Unable to connect. Retrying. ${this.factory.remainingRetries} attempts left.`
-            );
-            setTimeout(() => {
+          if (
+            error.code === "ECONNREFUSED"
+            && this.factory.remainingRetries > 0
+          ) {
+            if (Number.isFinite(this.factory.remainingRetries)) {
+              this.factory.remainingRetries -= 1;
+              console.error(
+                `Failed to connect. Address [${this.server.host}:${this.server.port}]. Retrying. ${this.factory.remainingRetries} attempts left.`
+              );
+            } else {
+              console.error(
+                `Failed to connect. Address [${this.server.host}:${this.server.port}]. Retrying.`
+              );
+            }
+            this.connectionTimeout = setTimeout(() => {
               retryConnection();
             }, this.factory.connectionTimeout);
           } else {

--- a/src/client/protocol/base.js
+++ b/src/client/protocol/base.js
@@ -60,8 +60,10 @@ class JsonRpcClientProtocol {
    * Calls [listen]{@link JsonRpcClientProtocol#listen} if connection was successful, and will resolve the promise.
    *
    * Will retry connection on the `connectionTimeout` interval.
-   * Number of connection retries is based on `remainingRetries`
-   * If `Infinity` is set for number of retries, then connections will attempt indefinitely
+   * Number of connection retries is based on `remainingRetries`.
+   *
+   * If `Infinity` (or some number that Javascript defines as non-finite `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite`)
+   * is set for number of retries, then connections will attempt indefinitely.
    *
    * Will reject the promise if connect or re-connect attempts fail.
    *

--- a/src/client/protocol/base.js
+++ b/src/client/protocol/base.js
@@ -116,10 +116,13 @@ class JsonRpcClientProtocol {
    *
    * Sets `JsonRpcClientFactory.pcolInstance` to `undefined`
    *
+   * Clears the connection timeout
+   *
    * @param {function} cb Called when connection is sucessfully closed
    */
   end(cb) {
     this.factory.pcolInstance = undefined;
+    clearTimeout(this.connectionTimeout);
     this.connector.end(cb);
   }
 

--- a/src/client/protocol/base.js
+++ b/src/client/protocol/base.js
@@ -61,6 +61,7 @@ class JsonRpcClientProtocol {
    *
    * Will retry connection on the `connectionTimeout` interval.
    * Number of connection retries is based on `remainingRetries`
+   * If `Infinity` is set for number of retries, then connections will attempt indefinitely
    *
    * Will reject the promise if connect or re-connect attempts fail.
    *

--- a/src/client/protocol/ws.js
+++ b/src/client/protocol/ws.js
@@ -30,49 +30,54 @@ class WsClientProtocol extends JsonRpcClientProtocol {
   /**
    * @inheritdoc
    */
-  connect() {
-    return new Promise((resolve, reject) => {
-      const retryConnection = () => {
-        this.setConnector();
-        this.connector.onopen = (event) => {
-          this.listener = this.connector;
-          this.listen();
-          resolve(event);
-        };
-        this.connector.onerror = (error) => {
-          // let the onclose event got it otherwise
-          if (error.error && error.error.code !== "ECONNREFUSED") {
-            reject(error);
-          }
-        };
-        this.connector.onclose = (event) => {
-          if (this.connector.__clientClosed) {
-            // we dont want to retry if the client purposefully closed the connection
-            console.log(
-              `Client closed connection. Code [${event.code}]. Reason [${event.reason}].`
-            );
-          } else {
-            if (this.factory.remainingRetries === 0) {
-              this.factory.pcolInstance = undefined;
-              reject(event);
-            } else {
-              this.factory.remainingRetries -= 1;
-              console.error(
-                `Connection failed. ${this.factory.remainingRetries} attempts left.`
-              );
-            }
-            setTimeout(() => {
-              retryConnection();
-            }, this.factory.connectionTimeout);
-          }
-        };
-      };
-      return retryConnection();
-    });
+  _retryConnection(resolve, reject) {
+    this.setConnector();
+    this.connector.onopen = (event) => {
+      this.listener = this.connector;
+      this.listen();
+      resolve(event);
+    };
+    this.connector.onerror = (error) => {
+      // let the onclose event get it otherwise
+      if (error.error && error.error.code !== "ECONNREFUSED") {
+        reject(error);
+      }
+    };
+    this.connector.onclose = (event) => {
+      if (this.connector.__clientClosed) {
+        // we dont want to retry if the client purposefully closed the connection
+        console.log(
+          `Client closed connection. Code [${event.code}]. Reason [${event.reason}].`
+        );
+      } else if (this.factory.remainingRetries > 0) {
+        this._onConnectionFailed(resolve, reject);
+      } else {
+        this.factory.pcolInstance = undefined;
+        reject(event);
+      }
+    };
+  }
+
+  /**
+   * @inheritdoc
+   */
+  _onConnectionFailed(resolve, reject) {
+    if (Number.isFinite(this.factory.remainingRetries)) {
+      this.factory.remainingRetries -= 1;
+      console.error(
+        `Failed to connect. Address [${this.url}]. Retrying. ${this.factory.remainingRetries} attempts left.`
+      );
+    } else {
+      console.error(`Failed to connect. Address [${this.url}]. Retrying.`);
+    }
+    this._connectionTimeout = setTimeout(() => {
+      this._retryConnection(resolve, reject);
+    }, this.factory.connectionTimeout);
   }
 
   /** @inheritdoc */
   end(code, reason) {
+    clearTimeout(this._connectionTimeout);
     this.factory.pcolInstance = undefined;
     this.connector.__clientClosed = true; // used to determine if client initiated close event
     this.connector.close(code, reason);

--- a/tests/connections/base-client-protocol.test.js
+++ b/tests/connections/base-client-protocol.test.js
@@ -50,7 +50,7 @@ describe("Base Client Reconnect", () => {
       );
       const pcolConnectionTimeout = infClient.pcolInstance._connectionTimeout;
       infClient.end();
-      expect(pcolConnectionTimeout._destroyed).to.equal(true);
+      expect(pcolConnectionTimeout._idleTimeout).to.equal(-1); // test _idleTimeout since _destroyed is not set immediately in v10.x
       done();
     }, 1000);
   }).timeout(10000);

--- a/tests/connections/base-client-protocol.test.js
+++ b/tests/connections/base-client-protocol.test.js
@@ -3,6 +3,7 @@ const intercept = require("intercept-stdout");
 const Jaysonic = require("../../src");
 
 const client = new Jaysonic.client.tcp({ retries: 1 });
+const infClient = new Jaysonic.client.tcp({ retries: Infinity });
 
 describe("Base Client Reconnect", () => {
   it("should retry the connection to the server and log the attempts", (done) => {
@@ -14,11 +15,26 @@ describe("Base Client Reconnect", () => {
     setTimeout(() => {
       unhook();
       expect(capturedText).to.equal(
-        "Unable to connect. Retrying. 0 attempts left.\n"
+        "Failed to connect. Address [127.0.0.1:8100]. Retrying. 0 attempts left.\n"
       );
     }, 100);
     conn.catch(() => {
       done();
     });
+  }).timeout(10000);
+  it("should retry the connection to the server indefinitely if retries set to 'Infinity'", (done) => {
+    infClient.connect();
+    let capturedText = "";
+    const unhook = intercept((text) => {
+      capturedText += text;
+    });
+    setTimeout(() => {
+      unhook();
+      expect(capturedText).to.equal(
+        "Failed to connect. Address [127.0.0.1:8100]. Retrying.\n"
+      );
+      infClient.end();
+      done();
+    }, 100);
   }).timeout(10000);
 });

--- a/tests/connections/base-client-protocol.test.js
+++ b/tests/connections/base-client-protocol.test.js
@@ -3,7 +3,7 @@ const intercept = require("intercept-stdout");
 const Jaysonic = require("../../src");
 
 const client = new Jaysonic.client.tcp({ retries: 1 });
-const infClient = new Jaysonic.client.tcp({ retries: Infinity });
+const infClient = new Jaysonic.client.tcp({ retries: null });
 
 describe("Base Client Reconnect", () => {
   it("should retry the connection to the server and log the attempts", (done) => {
@@ -22,7 +22,7 @@ describe("Base Client Reconnect", () => {
       done();
     });
   }).timeout(10000);
-  it("should retry the connection to the server indefinitely if retries set to 'Infinity'", (done) => {
+  it("should retry the connection to the server indefinitely if retries set to 'null'", (done) => {
     infClient.connect();
     let capturedText = "";
     const unhook = intercept((text) => {

--- a/tests/connections/base-client-protocol.test.js
+++ b/tests/connections/base-client-protocol.test.js
@@ -37,4 +37,21 @@ describe("Base Client Reconnect", () => {
       done();
     }, 100);
   }).timeout(10000);
+  it("should clear the _connectionTimeout of the protocol instance when connection ended", (done) => {
+    infClient.connect();
+    let capturedText = "";
+    const unhook = intercept((text) => {
+      capturedText += text;
+    });
+    setTimeout(() => {
+      unhook();
+      expect(capturedText).to.equal(
+        "Failed to connect. Address [127.0.0.1:8100]. Retrying.\n"
+      );
+      const pcolConnectionTimeout = infClient.pcolInstance._connectionTimeout;
+      infClient.end();
+      expect(pcolConnectionTimeout._destroyed).to.equal(true);
+      done();
+    }, 1000);
+  }).timeout(10000);
 });

--- a/tests/connections/ws-client-protocol.test.js
+++ b/tests/connections/ws-client-protocol.test.js
@@ -4,6 +4,7 @@ const Jaysonic = require("../../src");
 const { wss } = require("../test-server");
 
 const wsClient = new Jaysonic.client.ws({ retries: 1 });
+const infClient = new Jaysonic.client.ws({ retries: Infinity });
 
 describe("WS Client Reconnect", () => {
   it("should attempt to reconnect to the server and reject promise if unable", (done) => {
@@ -12,6 +13,38 @@ describe("WS Client Reconnect", () => {
       expect(error).to.be.an("object");
       done();
     });
+  }).timeout(10000);
+  it("should retry the connection to the server indefinitely if retries set to 'Infinity'", (done) => {
+    infClient.connect();
+    let capturedText = "";
+    const unhook = intercept((text) => {
+      capturedText += text;
+    });
+    setTimeout(() => {
+      unhook();
+      expect(capturedText).to.equal(
+        "Failed to connect. Address [ws://127.0.0.1:8100]. Retrying.\n"
+      );
+      infClient.end();
+      done();
+    }, 100);
+  }).timeout(10000);
+  it("should clear the _connectionTimeout of the protocol instance when connection ended", (done) => {
+    infClient.connect();
+    let capturedText = "";
+    const unhook = intercept((text) => {
+      capturedText += text;
+    });
+    setTimeout(() => {
+      unhook();
+      expect(capturedText).to.equal(
+        "Failed to connect. Address [ws://127.0.0.1:8100]. Retrying.\n"
+      );
+      const pcolConnectionTimeout = infClient.pcolInstance._connectionTimeout;
+      infClient.end();
+      expect(pcolConnectionTimeout._destroyed).to.equal(true);
+      done();
+    }, 1000);
   }).timeout(10000);
 });
 

--- a/tests/connections/ws-client-protocol.test.js
+++ b/tests/connections/ws-client-protocol.test.js
@@ -42,7 +42,7 @@ describe("WS Client Reconnect", () => {
       );
       const pcolConnectionTimeout = infClient.pcolInstance._connectionTimeout;
       infClient.end();
-      expect(pcolConnectionTimeout._destroyed).to.equal(true);
+      expect(pcolConnectionTimeout._idleTimeout).to.equal(-1); // test _idleTimeout since _destroyed is not set immediately in v10.x
       done();
     }, 1000);
   }).timeout(10000);

--- a/tests/connections/ws-client-protocol.test.js
+++ b/tests/connections/ws-client-protocol.test.js
@@ -4,7 +4,7 @@ const Jaysonic = require("../../src");
 const { wss } = require("../test-server");
 
 const wsClient = new Jaysonic.client.ws({ retries: 1 });
-const infClient = new Jaysonic.client.ws({ retries: Infinity });
+const infClient = new Jaysonic.client.ws({ retries: null });
 
 describe("WS Client Reconnect", () => {
   it("should attempt to reconnect to the server and reject promise if unable", (done) => {
@@ -14,7 +14,7 @@ describe("WS Client Reconnect", () => {
       done();
     });
   }).timeout(10000);
-  it("should retry the connection to the server indefinitely if retries set to 'Infinity'", (done) => {
+  it("should retry the connection to the server indefinitely if retries set to 'null'", (done) => {
     infClient.connect();
     let capturedText = "";
     const unhook = intercept((text) => {


### PR DESCRIPTION
- Add test for infinite retries. Refs #94.
- Clear connection timeout function when connection is ended.
    - with infinite retries this was not being cancelled in the back.
    - Refs #94

- Retry connection to server indefinitely if retries is set to null. Refs #94.
- Update docs to include new retry syntax. Refs #94.