### PR TITLE
Task/function to overwrite response headers

### DIFF
--- a/src/server/protocol/base.js
+++ b/src/server/protocol/base.js
@@ -337,7 +337,7 @@ class JsonRpcServerProtocol {
    * Writes error to the client. Will send a JSON-RPC error object if the
    * passed error cannot be parsed.
    *
-   * @param {string} error Stringified error object
+   * @param {Error} error `Error` object instance where the message should be a JSON-RPC message object
    */
   gotError(error) {
     let err;

--- a/src/server/protocol/base.js
+++ b/src/server/protocol/base.js
@@ -208,7 +208,7 @@ class JsonRpcServerProtocol {
    * Calls `emit` on factory with the event name being `message.method` and
    * the date being `message`.
    *
-   * @param {string} message Stringified JSON-RPC message object
+   * @param {string} message JSON-RPC message object
    */
   gotNotification(message) {
     this.factory.emit(message.method, message);

--- a/src/server/protocol/http.js
+++ b/src/server/protocol/http.js
@@ -24,8 +24,7 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
   }
 
   /**
-   * Send message to the client. If a notification is passed, then
-   * a 204 response code is sent.
+   * Send message to the client.
    *
    * @param {string} message Stringified JSON-RPC message object
    */
@@ -41,15 +40,12 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
         this.status = 200;
       }
     }
-    this.response.writeHead(this.status, this.headers);
-    this.response.write(message, () => {
-      this.response.end();
-    });
+    this.response.writeHead(this.status, this.headers).end(message);
   }
 
   /**
    * Calls `emit` on factory with the event name being `message.method` and
-   * the date being `message`. Responds to client.
+   * the data being `message`.
    *
    * Responds to client with 204 status.
    *
@@ -60,8 +56,7 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
     this.setResponseStatus({
       notification: true
     });
-    this.response.writeHead(this.status, this.headers);
-    this.response.end();
+    this.response.writeHead(this.status, this.headers).end();
   }
 
   /**
@@ -82,7 +77,6 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
    * @param {number} options.errorCode The JSON-RPC error code to lookup a corresponding status code for
    * @param {number} options.status The HTTP status code (will override the errorCode)
    * @param {boolean} options.notification Inidicate if setting header for notification (will override other options with 204 status)
-
    */
   setResponseStatus({ errorCode, status, notification }) {
     this.status = 200;

--- a/src/server/protocol/http.js
+++ b/src/server/protocol/http.js
@@ -12,11 +12,15 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
    * the following properties are available.
    *
    * @property {class} response HTTP response object
-   *
+   * @property {object} headers={"Content-Type": "application/json"} HTTP response headers
    */
   constructor(factory, client, response, version, delimiter) {
     super(factory, client, version, delimiter);
     this.response = response;
+    this.headers = {
+      "Content-Type": "application/json"
+    };
+    this.status = null;
   }
 
   /**
@@ -24,23 +28,20 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
    * a 204 response code is sent.
    *
    * @param {string} message Stringified JSON-RPC message object
-   * @param {boolean} notification Indicates if message is a notification
    */
-  writeToClient(message, notification) {
-    if (notification) {
-      this._setResponseHeader({
-        response: this.response,
-        notification: true
-      });
-      this.response.end();
-      return;
-    }
+  writeToClient(message) {
     const json = JSON.parse(message);
-    const header = { response: this.response };
-    if ("error" in json && json.error !== null) {
-      header.errorCode = json.error.code;
+    if (!this.status) {
+      // set the status code if it has not been overwritten
+      if (json.error) {
+        this.setResponseStatus({
+          errorCode: json.error.code
+        });
+      } else {
+        this.status = 200;
+      }
     }
-    this._setResponseHeader(header);
+    this.response.writeHead(this.status, this.headers);
     this.response.write(message, () => {
       this.response.end();
     });
@@ -54,10 +55,16 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
    */
   gotNotification(message) {
     super.gotNotification(message.method, message);
-    this.writeToClient(message, true);
+    this.setResponseStatus({
+      notification: true
+    });
+    this.response.writeHead(this.status, this.headers);
+    this.response.end();
   }
 
-  /** @inheritdoc */
+  /**
+   * @extends HttpServerProtocol.clientConnected
+   */
   clientConnected() {
     this.client.on(this.event, (data) => {
       this.client.on("end", () => {
@@ -67,26 +74,25 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
   }
 
   /**
-   * Set response header and response code
+   * Set response status code
    *
    * @param {object} options
-   * @param {class} options.response Http response instance
-   * @param {boolean} options.notification Inidicate if setting header for notification
    * @param {number} options.errorCode The JSON-RPC error code to lookup a corresponding status code for
-   * @private
+   * @param {number} options.status The HTTP status code (will override the errorCode)
+   * @param {boolean} options.notification Inidicate if setting header for notification (will override other options with 204 status)
+
    */
-  _setResponseHeader({ response, errorCode, notification }) {
-    let statusCode = 200;
-    if (notification) {
-      statusCode = 204;
-    }
-    const header = {
-      "Content-Type": "application/json"
-    };
+  setResponseStatus({ errorCode, status, notification }) {
+    this.status = 200;
     if (errorCode) {
-      statusCode = errorToStatus[String(errorCode)];
+      this.status = errorToStatus[String(errorCode)];
     }
-    response.writeHead(statusCode, header);
+    if (status) {
+      this.status = status;
+    }
+    if (notification) {
+      this.status = 204; // notification responses must be 204 per spec, so no point in allowing an override
+    }
   }
 }
 

--- a/src/server/protocol/http.js
+++ b/src/server/protocol/http.js
@@ -49,7 +49,7 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
    *
    * Responds to client with 204 status.
    *
-   * @param {string} message JSON-RPC message object
+   * @param {object} message JSON-RPC message object
    */
   gotNotification(message) {
     super.gotNotification(message.method, message);
@@ -60,12 +60,13 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
   }
 
   /**
-   * @extends HttpServerProtocol.clientConnected
+   * @extends JsonRpcServerProtocol.clientConnected
    */
   clientConnected() {
     this.client.on(this.event, (data) => {
       this.client.on("end", () => {
-        this._validateData(data);
+        this.messageBuffer.push(data);
+        this._waitForData();
       });
     });
   }

--- a/src/server/protocol/http.js
+++ b/src/server/protocol/http.js
@@ -51,7 +51,9 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
    * Calls `emit` on factory with the event name being `message.method` and
    * the date being `message`. Responds to client.
    *
-   * @param {string} message Stringified JSON-RPC message object
+   * Responds to client with 204 status.
+   *
+   * @param {string} message JSON-RPC message object
    */
   gotNotification(message) {
     super.gotNotification(message.method, message);

--- a/src/server/protocol/http.js
+++ b/src/server/protocol/http.js
@@ -60,6 +60,11 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
   }
 
   /**
+   * Registers the `event` data listener when client connects.
+   *
+   * Pushes received data into `messageBuffer` and calls
+   * [_waitForData]{@link JsonRpcServerProtocol#_waitForData}.
+   *
    * @extends JsonRpcServerProtocol.clientConnected
    */
   clientConnected() {

--- a/src/server/protocol/http.js
+++ b/src/server/protocol/http.js
@@ -12,7 +12,7 @@ class HttpServerProtocol extends JsonRpcServerProtocol {
    * the following properties are available.
    *
    * @property {class} response HTTP response object
-   * @property {object} headers={"Content-Type": "application/json"} HTTP response headers
+   * @property {object} headers={"Content-Type":"application/json"} HTTP response headers
    */
   constructor(factory, client, response, version, delimiter) {
     super(factory, client, version, delimiter);

--- a/tests/server/http-server-protocol.test.js
+++ b/tests/server/http-server-protocol.test.js
@@ -1,0 +1,61 @@
+const { expect } = require("chai");
+const Jaysonic = require("../../src/");
+const HttpServerFactory = require("../../src/server/http");
+const HttpServerProtocol = require("../../src/server/protocol/http");
+
+class Protocol extends HttpServerProtocol {
+  constructor(factory, client, response, version, delimiter) {
+    super(factory, client, response, version, delimiter);
+    this.status = 404;
+  }
+}
+
+class Factory extends HttpServerFactory {
+  constructor(options) {
+    super(options);
+    this.protocol = Protocol;
+  }
+}
+
+const server = new Factory({
+  port: 6969
+});
+const client = new Jaysonic.client.http({ port: 6969 });
+
+describe("HTTP Server Protocol Status Override", () => {
+  before((done) => {
+    server.listen().then(() => {
+      done();
+    });
+  });
+  after((done) => {
+    server.close().then(() => {
+      done();
+    });
+  });
+  it("should overwrite status code", (done) => {
+    client.send("foo").catch((e) => {
+      expect(e.body.error.code).to.be.eql(-32601);
+      expect(e.statusCode).to.be.eql(404);
+      done();
+    });
+  });
+  it("should overwrite errorCode if status is passed", (done) => {
+    class OverwritePcol extends HttpServerProtocol {
+      clientConnected() {
+        this.setResponseStatus({ errorCode: 400, status: 301 });
+        this.gotError(
+          new Error(
+            "{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32600, \"message\": \"Invalid Request\"}, \"id\": 2}"
+          )
+        );
+      }
+    }
+    server.protocol = OverwritePcol;
+    client.send("foo").catch((e) => {
+      expect(e.body.error.code).to.be.eql(-32600);
+      expect(e.statusCode).to.be.eql(301);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Use setResponseStatus to overwrite response status code

  - rename from setResponseHeaders
  - add class attribute for headers and status code
  - if status code is set, then dont use the one generated from the message
  (this allows a user to overwrite the status if its not one of the ones in
  errorToStatus)
  - send response for notification in gotNotification
  - Use .end() to send body data in response.write() and writeHead()