### PR TITLE
Improvement/#43/suppress console log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
       - [Client and server options](#client-and-server-options)
       - [Client only options](#client-only-options)
       - [Other client and server options](#other-client-and-server-options)
+    - [Logging](#logging)
     - [Code Demos](#code-demos)
       - [Initialization](#initialization-1)
           - [TCP](#tcp)
@@ -241,6 +242,25 @@ The WebSocket client supports an additional option in place of the host property
 The WebSocket server is based on the ws library (https://github.com/websockets/ws).
 
 It supports all of the options listed in their README. Typically changing the port is enough.
+
+### Logging
+
+`Jaysonic` includes a logging override to suppress or enhance the built in log messages for the library.
+
+By default `console` is used, but to overwrite this with your own logging function simply call `setLogger` before
+instantiating any clients or servers.
+
+All messages currently in the library are logged at the `info` and `error` levels.
+
+```javascript
+const Jaysonic = require("jaysonic");
+Jaysonic.logging.setLogger(myLogger); // overwrites `Logger.log` with custom logger
+
+const log = Jaysonic.logging.getLogger(); // returns `Logger.log` which is `console` by default
+log.info("foo"); // to use the logger returned from `getLogger`
+
+Jaysonic.logging.getInstance(); // returns instance of `Logger`
+```
 
 ### Code Demos
 

--- a/src/client/protocol/base.js
+++ b/src/client/protocol/base.js
@@ -1,6 +1,7 @@
 const { formatRequest, formatError } = require("../../util/format");
 const { ERR_CODES, ERR_MSGS } = require("../../util/constants");
 const MessageBuffer = require("../../util/buffer");
+const logging = require("../../util/logger");
 
 /**
  * Creates an instance of the base client protocol class.
@@ -117,16 +118,20 @@ class JsonRpcClientProtocol {
   _onConnectionFailed(error, resolve, reject) {
     if (this.factory.remainingRetries > 0) {
       this.factory.remainingRetries -= 1;
-      console.error(
-        `Failed to connect. Address [${this.server.host}:${this.server.port}]. Retrying. ${this.factory.remainingRetries} attempts left.`
-      );
+      logging
+        .getLogger()
+        .info(
+          `Failed to connect. Address [${this.server.host}:${this.server.port}]. Retrying. ${this.factory.remainingRetries} attempts left.`
+        );
     } else if (this.factory.remainingRetries === 0) {
       this.factory.pcolInstance = undefined;
       return reject(error);
     } else {
-      console.error(
-        `Failed to connect. Address [${this.server.host}:${this.server.port}]. Retrying.`
-      );
+      logging
+        .getLogger()
+        .info(
+          `Failed to connect. Address [${this.server.host}:${this.server.port}]. Retrying.`
+        );
     }
     this._connectionTimeout = setTimeout(() => {
       this._retryConnection(resolve, reject);

--- a/src/client/protocol/base.js
+++ b/src/client/protocol/base.js
@@ -285,9 +285,11 @@ class JsonRpcClientProtocol {
     } catch (e) {
       if (e instanceof TypeError) {
         // response id likely not in the queue
-        console.error(
-          `Message has no outstanding calls: ${JSON.stringify(message)}`
-        );
+        logging
+          .getLogger()
+          .error(
+            `Message has no outstanding calls: ${JSON.stringify(message)}`
+          );
       }
     }
   }
@@ -509,7 +511,9 @@ class JsonRpcClientProtocol {
         delete this.pendingCalls[id];
       } catch (e) {
         if (e instanceof TypeError) {
-          console.error(`Message has no outstanding calls. ID [${id}]`);
+          logging
+            .getLogger()
+            .error(`Message has no outstanding calls. ID [${id}]`);
         }
       }
     }, this.factory.requestTimeout);
@@ -544,9 +548,11 @@ class JsonRpcClientProtocol {
     } catch (e) {
       if (e instanceof TypeError) {
         // no outstanding calls
-        console.log(
-          `Batch response has no outstanding calls. Response IDs [${batchIds}]`
-        );
+        logging
+          .getLogger()
+          .log(
+            `Batch response has no outstanding calls. Response IDs [${batchIds}]`
+          );
       }
     }
   }
@@ -599,7 +605,8 @@ class JsonRpcClientProtocol {
   /**
    * Reject the pending call for the given ID is in the error object.
    *
-   * If the error object has a null id, then log the message to the console.
+   * If the error object has a null id, then log the message to the logging
+        .getLogger().
    *
    * @param {string} error Stringified JSON-RPC error object
    *
@@ -611,9 +618,9 @@ class JsonRpcClientProtocol {
     } catch (e) {
       if (e instanceof TypeError) {
         // error object id probably not a pending response
-        console.error(
-          `Message has no outstanding calls: ${JSON.stringify(error)}`
-        );
+        logging
+          .getLogger()
+          .error(`Message has no outstanding calls: ${JSON.stringify(error)}`);
       }
     }
   }

--- a/src/client/protocol/http.js
+++ b/src/client/protocol/http.js
@@ -1,6 +1,7 @@
 const http = require("http");
 const https = require("https");
 const JsonRpcClientProtocol = require("./base");
+const logging = require("../../util/logger");
 
 /**
  * Creates an instance of HttpClientProtocol, which has some tweaks from the base class
@@ -178,9 +179,11 @@ class HttpClientProtocol extends JsonRpcClientProtocol {
     } catch (e) {
       if (e instanceof TypeError) {
         // probably a parse error, which might not have an id
-        console.error(
-          `Message has no outstanding calls: ${JSON.stringify(err.body)}`
-        );
+        logging
+          .getLogger()
+          .error(
+            `Message has no outstanding calls: ${JSON.stringify(err.body)}`
+          );
       }
     }
   }

--- a/src/client/protocol/ws.js
+++ b/src/client/protocol/ws.js
@@ -1,5 +1,6 @@
 const WebSocket = require("ws");
 const JsonRpcClientProtocol = require("./base");
+const logging = require("../../util/logger");
 
 /**
  * Creates and instance of WsClientProtocol
@@ -46,9 +47,11 @@ class WsClientProtocol extends JsonRpcClientProtocol {
     this.connector.onclose = (event) => {
       if (this.connector.__clientClosed) {
         // we dont want to retry if the client purposefully closed the connection
-        console.log(
-          `Client closed connection. Code [${event.code}]. Reason [${event.reason}].`
-        );
+        logging
+          .getLogger()
+          .log(
+            `Client closed connection. Code [${event.code}]. Reason [${event.reason}].`
+          );
       } else {
         return this._onConnectionFailed(event, resolve, reject);
       }
@@ -61,14 +64,18 @@ class WsClientProtocol extends JsonRpcClientProtocol {
   _onConnectionFailed(event, resolve, reject) {
     if (this.factory.remainingRetries > 0) {
       this.factory.remainingRetries -= 1;
-      console.error(
-        `Failed to connect. Address [${this.url}]. Retrying. ${this.factory.remainingRetries} attempts left.`
-      );
+      logging
+        .getLogger()
+        .error(
+          `Failed to connect. Address [${this.url}]. Retrying. ${this.factory.remainingRetries} attempts left.`
+        );
     } else if (this.factory.remainingRetries === 0) {
       this.factory.pcolInstance = undefined;
       return reject(event);
     } else {
-      console.error(`Failed to connect. Address [${this.url}]. Retrying.`);
+      logging
+        .getLogger()
+        .error(`Failed to connect. Address [${this.url}]. Retrying.`);
     }
     this._connectionTimeout = setTimeout(() => {
       this._retryConnection(resolve, reject);

--- a/src/index.js
+++ b/src/index.js
@@ -15,3 +15,9 @@ Jaysonic.client = require("./client");
  * @type JsonRpcServerFactory
  */
 Jaysonic.server = require("./server");
+
+/**
+ * @static
+ * @type Object
+ */
+Jaysonic.logging = require("./util/logger");

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,0 +1,28 @@
+class Logger {
+  constructor() {
+    this.log = console;
+  }
+}
+
+class Singleton {
+  constructor() {
+    if (!Singleton.instance) {
+      Singleton.instance = new Logger();
+    }
+  }
+
+  getInstance() {
+    return Singleton.instance;
+  }
+}
+
+const logging = {
+  setLogger(newLogger) {
+    new Singleton().getInstance().log = newLogger;
+  },
+  getLogger() {
+    return new Singleton().getInstance().log;
+  }
+};
+
+module.exports = logging;

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,4 +1,9 @@
 class Logger {
+  /**
+   * Singleton logging class to provide custom logger for library
+   *
+   * @returns instance of Logger
+   */
   constructor() {
     if (Logger._instance) {
       return Logger._instance;
@@ -17,12 +22,28 @@ class Logger {
 }
 
 const logging = {
+  /**
+   * Singleton logging class to provide custom logger for library
+   *
+   * @returns instance of Logger
+   */
   setLogger(newLogger) {
     new Logger().setLogger(newLogger);
   },
+  /**
+   * Overwrite Logger.log, default `console`, which is used for
+   * messages within the library
+   *
+   * @param {object} newLogger Object to overwrite `console` logging
+   */
   getLogger() {
     return new Logger().getLogger().log;
   },
+  /**
+   * Get `Logger` instance
+   *
+   * @returns instance of Logger
+   */
   getInstance() {
     return new Logger().getLogger();
   }

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,27 +1,30 @@
 class Logger {
   constructor() {
+    if (Logger._instance) {
+      return Logger._instance;
+    }
+    Logger._instance = this;
     this.log = console;
   }
-}
 
-class Singleton {
-  constructor() {
-    if (!Singleton.instance) {
-      Singleton.instance = new Logger();
-    }
+  setLogger(newLogger) {
+    this.log = newLogger;
   }
 
-  getInstance() {
-    return Singleton.instance;
+  getLogger() {
+    return Logger._instance || new Logger();
   }
 }
 
 const logging = {
   setLogger(newLogger) {
-    new Singleton().getInstance().log = newLogger;
+    new Logger().setLogger(newLogger);
   },
   getLogger() {
-    return new Singleton().getInstance().log;
+    return new Logger().getLogger().log;
+  },
+  getInstance() {
+    return new Logger().getLogger();
   }
 };
 

--- a/tests/util/logger.test.js
+++ b/tests/util/logger.test.js
@@ -1,0 +1,21 @@
+const { expect } = require("chai");
+const logging = require("../../src/util/logger");
+
+describe("Logger", () => {
+  it("should return new instance of logger", () => {
+    const logger = logging.getInstance();
+    expect(logger.log).to.be.eql(console);
+  });
+  it("should return logger.log", () => {
+    const logger = logging.getLogger();
+    expect(logger).to.be.eql(console);
+  });
+  it("should instantiate a new logging function", () => {
+    const newLogger = {};
+    logging.setLogger(newLogger);
+    expect(logging.getLogger()).to.eql(newLogger);
+    // set it back to console over to not mess up other tests
+    logging.setLogger(console);
+    expect(logging.getLogger()).to.eql(console);
+  });
+});


### PR DESCRIPTION
Add documentation for logger. Refs #43.

Add logger tests. Refs #43.

Simplify class

- add getInstance method to just return the logger instance
- Refs #43

Update console prints in all files to use new logger

Is this a singleton?

- make singleton logger class for library
- uses console by default or can be overwritten in main function
- Refs #43