### PR TITLE
Bugfix/#123/reconnect after receiving server disconnected

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/src/client/protocol/base.js
+++ b/src/client/protocol/base.js
@@ -91,6 +91,7 @@ class JsonRpcClientProtocol {
     this.connector.connect(this.server);
     this.connector.setEncoding("utf8");
     this.connector.on("connect", () => {
+      this.factory.remainingRetries = this.factory.options.retries;
       this.listener = this.connector;
       this.listen();
       resolve(this.server);

--- a/src/client/protocol/base.js
+++ b/src/client/protocol/base.js
@@ -95,9 +95,13 @@ class JsonRpcClientProtocol {
       this.listen();
       resolve(this.server);
     });
-    this.connector.on("error", error => this._onConnectionFailed(error, resolve, reject));
-    this.connector.on("close", () => {
-      this.factory.emit("serverDisconnected");
+    this.connector.on("error", (error) =>
+      this._onConnectionFailed(error, resolve, reject)
+    );
+    this.connector.on("close", (hadError) => {
+      if (!hadError) {
+        this.factory.emit("serverDisconnected");
+      }
     });
   }
 

--- a/tests/issues/#123-reconnect-after-serverDisconnected.test.js
+++ b/tests/issues/#123-reconnect-after-serverDisconnected.test.js
@@ -1,0 +1,37 @@
+const { expect } = require("chai");
+const Jaysonic = require("../../src");
+const { server } = require("../test-server");
+const intercept = require("intercept-stdout");
+
+const tcpclient = new Jaysonic.client.tcp({
+  retries: 10
+});
+
+describe("#123 Reconnect after serverDisconnected", () => {
+  before(async () => {
+    await server.listen();
+    await tcpclient.connect();
+  });
+  after(async () => {
+    await tcpclient.end();
+  });
+  it("should attempt to reconnect at the default rate after receiving a serverDisconnected", async () => {
+    let reconnectAttempts = 0;
+    let capturedText = "";
+    const unhook = intercept((text) => {
+      capturedText += text;
+    });
+    tcpclient.serverDisconnected(async () => {
+      reconnectAttempts += 1;
+      tcpclient.pcolInstance = null;
+      await tcpclient.connect();
+    });
+    await server.close();
+    await new Promise((r) => setTimeout(r, 10000));
+    unhook();
+    expect(capturedText).to.equal(
+      `Failed to connect. Address [127.0.0.1:8100]. Retrying. 9 attempts left.\nFailed to connect. Address [127.0.0.1:8100]. Retrying. 8 attempts left.\n`
+    );
+    expect(reconnectAttempts).to.equal(1);
+  }).timeout(30000);
+});

--- a/tests/issues/#123-reconnect-after-serverDisconnected.test.js
+++ b/tests/issues/#123-reconnect-after-serverDisconnected.test.js
@@ -8,11 +8,10 @@ const tcpclient = new Jaysonic.client.tcp({
 });
 
 describe("#123 Reconnect after serverDisconnected", () => {
-  before(async () => {
+  beforeEach(async () => {
     await server.listen();
-    await tcpclient.connect();
   });
-  after(async () => {
+  afterEach(async () => {
     await tcpclient.end();
   });
   it("should attempt to reconnect at the default rate after receiving a serverDisconnected", async () => {
@@ -26,9 +25,14 @@ describe("#123 Reconnect after serverDisconnected", () => {
       tcpclient.pcolInstance = null;
       await tcpclient.connect();
     });
+    await tcpclient.connect();
     await server.close();
     await new Promise((r) => setTimeout(r, 10000));
     unhook();
+    // first re-connect attempt is done without error
+    // second is done with error and does not trigger the serverDisconnected call
+    // after which the test should timeout
+    // 2 attempts, 5s apart 10s total
     expect(capturedText).to.equal(
       `Failed to connect. Address [127.0.0.1:8100]. Retrying. 9 attempts left.\nFailed to connect. Address [127.0.0.1:8100]. Retrying. 8 attempts left.\n`
     );


### PR DESCRIPTION
Call serverDisconnected only if connection was closed without error

- it should otherwise be handled by the .on('error') event
- Refs #123