### PR TITLE
Bugfix/#125/ci tests fail node 18 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/src/client/protocol/http.js
+++ b/src/client/protocol/http.js
@@ -62,14 +62,14 @@ class HttpClientProtocol extends JsonRpcClientProtocol {
     } else {
       throw Error("Invalid scheme");
     }
-    this.connector.write(request, this.encoding);
-    this.connector.end();
     this.connector.on("close", () => {
       this.factory.emit("serverDisconnected");
     });
     this.connector.on("error", (error) => {
       throw error;
     });
+    this.connector.write(request, this.encoding);
+    this.connector.end();
   }
 
   /**

--- a/tests/client/http-client.test.js
+++ b/tests/client/http-client.test.js
@@ -7,7 +7,11 @@ const { serverHttp } = require("../test-server");
 
 chai.use(spies);
 
-const clientHttp = new Jaysonic.client.http();
+const clientHttp = new Jaysonic.client.http({
+  headers: {
+    Connection: "close"
+  }
+});
 
 describe("HTTP Client", () => {
   before((done) => {
@@ -16,7 +20,7 @@ describe("HTTP Client", () => {
       .then(() => {
         done();
       })
-      .catch(e => console.log(e));
+      .catch((e) => console.log(e));
   });
   after((done) => {
     serverHttp
@@ -24,7 +28,7 @@ describe("HTTP Client", () => {
       .then(() => {
         done();
       })
-      .catch(e => console.log(e));
+      .catch((e) => console.log(e));
   });
   describe("connection", () => {
     // it("should receive error trying to write while disconnected", (done) => {

--- a/tests/client/https-client.test.js
+++ b/tests/client/https-client.test.js
@@ -5,7 +5,10 @@ const { serverHttps } = require("../test-server");
 
 const clienthttps = new Jaysonic.client.http({
   scheme: "https",
-  rejectUnauthorized: false
+  rejectUnauthorized: false,
+  headers: {
+    Connection: "close"
+  }
 });
 
 describe("HTTPS Client", () => {
@@ -15,7 +18,7 @@ describe("HTTPS Client", () => {
       .then(() => {
         done();
       })
-      .catch(e => console.log(e));
+      .catch((e) => console.log(e));
   });
   after((done) => {
     serverHttps
@@ -23,7 +26,7 @@ describe("HTTPS Client", () => {
       .then(() => {
         done();
       })
-      .catch(e => console.log(e));
+      .catch((e) => console.log(e));
   });
   describe("connection", () => {
     // it("should receive error trying to write while disconnected", (done) => {

--- a/tests/issues/#51-no-params.test.js
+++ b/tests/issues/#51-no-params.test.js
@@ -3,7 +3,11 @@ const Jaysonic = require("../../src");
 const { server, serverHttp, wss } = require("../test-server");
 
 const tcpclient = new Jaysonic.client.tcp();
-const httpclient = new Jaysonic.client.http();
+const httpclient = new Jaysonic.client.http({
+  headers: {
+    Connection: "close"
+  }
+});
 const wsclient = new Jaysonic.client.ws();
 
 const noParams = () => "success";

--- a/tests/notifications_and_subscriptions/http-client-protocol.test.js
+++ b/tests/notifications_and_subscriptions/http-client-protocol.test.js
@@ -5,7 +5,10 @@ const http = new Jaysonic.client.http({
   host: "httpbin.org",
   path: "/status/200",
   scheme: "https",
-  port: 443
+  port: 443,
+  headers: {
+    Connection: "close"
+  }
 });
 
 describe("Http Client Protocol Notifications", () => {

--- a/tests/server/http-server-protocol.test.js
+++ b/tests/server/http-server-protocol.test.js
@@ -20,7 +20,12 @@ class Factory extends HttpServerFactory {
 const server = new Factory({
   port: 6969
 });
-const client = new Jaysonic.client.http({ port: 6969 });
+const client = new Jaysonic.client.http({
+  port: 6969,
+  headers: {
+    Connection: "close"
+  }
+});
 
 describe("HTTP Server Protocol Status Override", () => {
   before((done) => {
@@ -46,7 +51,7 @@ describe("HTTP Server Protocol Status Override", () => {
         this.setResponseStatus({ errorCode: 400, status: 301 });
         this.gotError(
           new Error(
-            "{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32600, \"message\": \"Invalid Request\"}, \"id\": 2}"
+            '{"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": 2}'
           )
         );
       }

--- a/tests/server/http-server.test.js
+++ b/tests/server/http-server.test.js
@@ -48,8 +48,18 @@ describe("Http Server", () => {
       });
     });
     it("should handle requests from multiple clients", (done) => {
-      const client1 = new Jaysonic.client.http({ port: 8100 });
-      const client2 = new Jaysonic.client.http({ port: 8100 });
+      const client1 = new Jaysonic.client.http({
+        port: 8100,
+        headers: {
+          Connection: "close"
+        }
+      });
+      const client2 = new Jaysonic.client.http({
+        port: 8100,
+        headers: {
+          Connection: "close"
+        }
+      });
       const req1 = client1.request().send("params", [1, 2]);
       const req2 = client2.request().send("named.params", { name: "jaysonic" });
       Promise.all([req1, req2]).then((results) => {

--- a/tests/server/http-server.test.js
+++ b/tests/server/http-server.test.js
@@ -7,7 +7,7 @@ const { serverHttp, serverHttpV1 } = require("../test-server");
 
 chai.use(chaiHttp);
 
-const httpRequest = chai.request("http://localhost:8100");
+const httpRequest = chai.request("http://127.0.0.1:8100");
 
 describe("Http Server", () => {
   after((done) => {
@@ -137,6 +137,7 @@ describe("Http Server", () => {
         .set("Content-Type", "application/json")
         .send("{]\n")
         .end((error, response) => {
+          console.log(error, response);
           expect(JSON.parse(response.text)).to.be.eql({
             jsonrpc: "2.0",
             error: { code: -32700, message: "Parse Error" },

--- a/tests/server/http-server.test.js
+++ b/tests/server/http-server.test.js
@@ -137,7 +137,6 @@ describe("Http Server", () => {
         .set("Content-Type", "application/json")
         .send("{]\n")
         .end((error, response) => {
-          console.log(error, response);
           expect(JSON.parse(response.text)).to.be.eql({
             jsonrpc: "2.0",
             error: { code: -32700, message: "Parse Error" },

--- a/tests/test-client.js
+++ b/tests/test-client.js
@@ -3,7 +3,11 @@ const Jaysonic = require("../src");
 const WebSocket = require("../src/client-ws");
 
 const client = new Jaysonic.client.tcp();
-const clienthttp = new Jaysonic.client.http();
+const clienthttp = new Jaysonic.client.http({
+  headers: {
+    Connection: "close"
+  }
+});
 const socket = new net.Socket();
 const socketV1 = new net.Socket();
 


### PR DESCRIPTION
- Add nodejs 18.x and 20.x to CI workflow
- Update tests to use the Connection: close header for the http clients